### PR TITLE
Add felt_div

### DIFF
--- a/core/src/sierra/corelib_functions/math/div.rs
+++ b/core/src/sierra/corelib_functions/math/div.rs
@@ -1,0 +1,118 @@
+use cairo_lang_sierra::program::LibfuncDeclaration;
+use inkwell::types::{BasicType, StringRadix};
+use inkwell::values::AnyValue;
+use inkwell::IntPredicate;
+
+use super::DEFAULT_PRIME;
+use crate::sierra::errors::{CompilerResult, DEBUG_NAME_EXPECTED};
+use crate::sierra::llvm_compiler::Compiler;
+
+impl<'a, 'ctx> Compiler<'a, 'ctx> {
+    /// Implementation of the LLVM IR conversion of a felt division.
+    ///
+    /// # Arguments
+    ///
+    /// * `libfunc_declaration` - The corelib function declaration of felt_div.
+    ///
+    /// # Error
+    ///
+    /// Returns an error if the felt type has not been declared previously.
+    pub fn felt_div(&self, libfunc_declaration: &LibfuncDeclaration) {
+        // We could hardcode the LLVM IR type for felt but this adds a check.
+        let felt_type = self.get_type_from_name("felt").unwrap();
+        // fn felt_div(a: felt, b: felt) -> felt
+        let func = self.module.add_function(
+            libfunc_declaration.id.debug_name.clone().expect(DEBUG_NAME_EXPECTED).to_string().as_str(),
+            felt_type.fn_type(&[felt_type.as_basic_type_enum().into(), felt_type.as_basic_type_enum().into()], false),
+            None,
+        );
+
+        let entry_block = self.context.append_basic_block(func, "entry");
+        let while_loop = self.context.append_basic_block(func, "while");
+        let body_loop = self.context.append_basic_block(func, "body");
+        let exit_loop = self.context.append_basic_block(func, "exit");
+
+        self.builder.position_at_end(entry_block);
+
+        // The maximum value of a multiplication is (prime - 1)² which is 503 bits.
+        let double_felt = self.context.custom_width_int_type(503);
+
+        let prime = double_felt
+            .const_int_from_string(DEFAULT_PRIME, inkwell::types::StringRadix::Decimal)
+            .expect("Should have been able to parse the prime");
+
+        // Compute felt division = a * b^-1
+
+        // Calculate the multiplicative inverse of b
+
+        let t = self.builder.build_alloca(double_felt, "t");
+        let new_t = self.builder.build_alloca(double_felt, "new_t");
+        let r = self.builder.build_alloca(double_felt, "r");
+        let new_r = self.builder.build_alloca(double_felt, "new_r");
+        let quotient = self.builder.build_alloca(double_felt, "quotient");
+
+        self.builder.build_store(t, double_felt.const_int(0, false));
+        self.builder.build_store(new_t, double_felt.const_int(1, false));
+        self.builder.build_store(r, prime);
+        self.builder
+            .build_store(new_r, func.get_last_param().expect("felt_div should have a second arg").into_int_value());
+
+        self.builder.build_unconditional_branch(while_loop);
+        self.builder.position_at_end(while_loop);
+
+        let new_r_value = self.builder.build_load(double_felt, new_r, "new_r_value");
+
+        let is_new_t_zero = self.builder.build_int_compare(
+            IntPredicate::NE,
+            new_r_value.into_int_value(),
+            double_felt.const_int(0, false).as_any_value_enum().into_int_value(),
+            "while_compare",
+        );
+
+        self.builder.build_conditional_branch(is_new_t_zero, body_loop, exit_loop);
+
+        // while loop body
+        self.builder.position_at_end(body_loop);
+
+        self.builder.build_unconditional_branch(while_loop);
+
+        self.builder.position_at_end(exit_loop);
+
+        // let const_1 = felt_type.into_int_type().const_int(1, false);
+        // let b_pow_minus_1 = self.builder.build_int_signed_div(
+        // const_1,
+        // func.get_last_param().expect("felt_div should have a second arg").into_int_value(),
+        // "b_pow_minus_1",
+        // );
+
+        // Extend left hand side.
+        let lhs = self.builder.build_int_s_extend(
+            func.get_first_param().expect("felt_div should have a first arg").into_int_value(),
+            double_felt,
+            "extended_a",
+        );
+        // Extend right hand side.
+        let rhs = self.builder.build_int_s_extend(
+            func.get_last_param().expect("felt_div should have a second arg").into_int_value(),
+            double_felt,
+            "extended_b",
+        );
+
+        let mul = self.builder.build_int_mul(lhs, rhs, "res");
+        // Panics if the function doesn't have enough arguments but it shouldn't happen since we just
+        // defined it above.
+        // Also panics if the modulo function doesn't return a value but it shouldn't happen.
+        // return a * b % prime
+        let res = self
+            .builder
+            .build_call(
+                self.module.get_function("modulo").expect("Modulo should have been defined before"),
+                &[mul.into()],
+                "res",
+            )
+            .try_as_basic_value()
+            .left()
+            .expect("Should have a left return value");
+        self.builder.build_return(Some(&res));
+    }
+}

--- a/core/src/sierra/corelib_functions/math/div.rs
+++ b/core/src/sierra/corelib_functions/math/div.rs
@@ -4,7 +4,7 @@ use inkwell::values::AnyValue;
 use inkwell::IntPredicate;
 
 use super::DEFAULT_PRIME;
-use crate::sierra::errors::{CompilerResult, DEBUG_NAME_EXPECTED};
+use crate::sierra::errors::DEBUG_NAME_EXPECTED;
 use crate::sierra::llvm_compiler::Compiler;
 
 impl<'a, 'ctx> Compiler<'a, 'ctx> {

--- a/core/src/sierra/corelib_functions/math/mod.rs
+++ b/core/src/sierra/corelib_functions/math/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod constants;
+pub mod div;
 pub mod modulo;
 pub mod mul;
 pub mod sub;

--- a/core/src/sierra/process/corelib.rs
+++ b/core/src/sierra/process/corelib.rs
@@ -30,6 +30,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 "felt_const" => self.felt_const(libfunc_declaration),
                 "felt_is_zero" => debug!(libfunc_name, "treated in the statements"),
                 "felt_mul" => self.felt_mul(libfunc_declaration),
+                "felt_div" => self.felt_div(libfunc_declaration),
                 "felt_sub" => self.felt_sub(libfunc_declaration),
                 "function_call" => debug!(libfunc_name, "treated in the statements"),
                 "into_box" => self.into_box(libfunc_declaration),

--- a/core/tests/sierra_to_llvm.rs
+++ b/core/tests/sierra_to_llvm.rs
@@ -16,6 +16,7 @@ macro_rules! test_resource_file {
 #[test_case("fib_box")]
 #[test_case("fib_box_main")]
 #[test_case("struct_construct")]
+#[test_case("division")]
 fn compile_sierra_program_to_llvm(name: &str) {
     let program_path = test_resource_file!(format!("sierra/{}.sierra", name));
     let tmp_dir = TempDir::new("tmp").unwrap();

--- a/core/tests/test_data/llvm/division.ll
+++ b/core/tests/test_data/llvm/division.ll
@@ -1,0 +1,100 @@
+; ModuleID = 'root'
+source_filename = "root"
+target triple = "x86_64-pc-linux-gnu"
+
+define i252 @modulo(i503 %0) {
+entry:
+  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i503 %modulus to i252
+  ret i252 %res
+}
+
+define i252 @"felt_const<6>"() {
+entry:
+  ret i252 6
+}
+
+define i252 @"felt_const<2>"() {
+entry:
+  ret i252 2
+}
+
+define i252 @"store_temp<felt>"(i252 %0) {
+entry:
+  ret i252 %0
+}
+
+define i252 @felt_div(i252 %0, i252 %1) {
+entry:
+  %t = alloca i503, align 8
+  %new_t = alloca i503, align 8
+  %r = alloca i503, align 8
+  %new_r = alloca i503, align 8
+  store i503 0, ptr %t, align 4
+  store i503 1, ptr %new_t, align 4
+  store i503 3618502788666131213697322783095070105623107215331596699973092056135872020481, ptr %r, align 4
+  %new_r_extended = sext i252 %1 to i503
+  store i503 %new_r_extended, ptr %new_r, align 4
+  br label %while
+
+while:                                            ; preds = %body, %entry
+  %new_r_value = load i503, ptr %new_r, align 4
+  %while_compare = icmp ne i503 %new_r_value, 0
+  br i1 %while_compare, label %body, label %exit
+
+body:                                             ; preds = %while
+  %r_value = load i503, ptr %r, align 4
+  %new_r_value1 = load i503, ptr %new_r, align 4
+  %new_quotient_value = sdiv i503 %r_value, %new_r_value1
+  %old_t_value = load i503, ptr %t, align 4
+  %new_t_value = load i503, ptr %new_t, align 4
+  store i503 %new_t_value, ptr %t, align 4
+  %quotient_mul_new_t = mul i503 %new_quotient_value, %new_t_value
+  %sub_t_res = sub i503 %old_t_value, %quotient_mul_new_t
+  store i503 %sub_t_res, ptr %new_t, align 4
+  %old_r_value = load i503, ptr %r, align 4
+  %new_r_value2 = load i503, ptr %new_r, align 4
+  store i503 %new_r_value2, ptr %r, align 4
+  %quotient_mul_new_r = mul i503 %new_quotient_value, %new_r_value2
+  %sub_r_res = sub i503 %old_r_value, %quotient_mul_new_r
+  store i503 %sub_r_res, ptr %new_r, align 4
+  br label %while
+
+exit:                                             ; preds = %while
+  %extended_a = sext i252 %0 to i503
+  %inverse = load i503, ptr %t, align 4
+  %res = mul i503 %extended_a, %inverse
+  %res3 = call i252 @modulo(i503 %res)
+  ret i252 %res3
+}
+
+define i252 @"rename<felt>"(i252 %0) {
+entry:
+  ret i252 %0
+}
+
+declare i32 @printf(ptr, ...)
+
+define i32 @print({ i252 } %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
+  ret i32 %worked
+}
+
+define i32 @main() {
+entry:
+  %0 = call i252 @"felt_const<6>"()
+  %1 = call i252 @"felt_const<2>"()
+  %2 = call i252 @"store_temp<felt>"(i252 %0)
+  %3 = call i252 @felt_div(i252 %2, i252 %1)
+  %4 = call i252 @"store_temp<felt>"(i252 %3)
+  %5 = call i252 @"rename<felt>"(i252 %4)
+  %ret_struct_ptr = alloca { i252 }, align 8
+  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i252 %5, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
+  %worked = call i32 @print({ i252 } %return_struct_value)
+  ret i32 %worked
+}

--- a/core/tests/test_data/sierra/division.sierra
+++ b/core/tests/test_data/sierra/division.sierra
@@ -1,0 +1,17 @@
+type felt = felt;
+
+libfunc felt_const<6> = felt_const<6>;
+libfunc felt_const<2> = felt_const<2>;
+libfunc store_temp<felt> = store_temp<felt>;
+libfunc felt_div = felt_div;
+libfunc rename<felt> = rename<felt>;
+
+felt_const<6>() -> ([0]);
+felt_const<2>() -> ([1]);
+store_temp<felt>([0]) -> ([0]);
+felt_div([0], [1]) -> ([2]);
+store_temp<felt>([2]) -> ([2]);
+rename<felt>([2]) -> ([3]);
+return([3]);
+
+add::add::main@0() -> (felt);


### PR DESCRIPTION
Adds support for felt division

`a * b^-1 % prime`

I made the inverse from this rusty pseudocode:

```rust
pub fn inverse(&self) -> Self {
        let (mut t, mut new_t) = (0, 1);
        let (mut r, mut new_r) = (FieldElement::k_modulus(), self.0);
        while new_r != 0 {
            let quotient = r / new_r;
            (t, new_t) = (new_t, t - (quotient * new_t));
            (r, new_r) = (new_r, r - quotient * new_r);
        }
        assert!(r == 1);
        FieldElement::new(t)
}
```

Need to figure out how to add tests and then I'll do so soon.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Currently felt_div libfunc is not implemented.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# What is the new behavior?

The felt_div libfunc is implemented.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Feel free to tell me any errors or issues and I'll fix them asap.

## Example IR generated

```llvm
define i252 @felt_div(i252 %0, i252 %1) {
entry:
  %t = alloca i503, align 8
  %new_t = alloca i503, align 8
  %r = alloca i503, align 8
  %new_r = alloca i503, align 8
  store i503 0, ptr %t, align 4
  store i503 1, ptr %new_t, align 4
  store i503 3618502788666131213697322783095070105623107215331596699973092056135872020481, ptr %r, align 4
  %new_r_extended = sext i252 %1 to i503
  store i503 %new_r_extended, ptr %new_r, align 4
  br label %while

while:                                            ; preds = %body, %entry
  %new_r_value = load i503, ptr %new_r, align 4
  %while_compare = icmp ne i503 %new_r_value, 0
  br i1 %while_compare, label %body, label %exit

body:                                             ; preds = %while
  %r_value = load i503, ptr %r, align 4
  %new_r_value1 = load i503, ptr %new_r, align 4
  %new_quotient_value = sdiv i503 %r_value, %new_r_value1
  %old_t_value = load i503, ptr %t, align 4
  %new_t_value = load i503, ptr %new_t, align 4
  store i503 %new_t_value, ptr %t, align 4
  %quotient_mul_new_t = mul i503 %new_quotient_value, %new_t_value
  %sub_t_res = sub i503 %old_t_value, %quotient_mul_new_t
  store i503 %sub_t_res, ptr %new_t, align 4
  %old_r_value = load i503, ptr %r, align 4
  %new_r_value2 = load i503, ptr %new_r, align 4
  store i503 %new_r_value2, ptr %r, align 4
  %quotient_mul_new_r = mul i503 %new_quotient_value, %new_r_value2
  %sub_r_res = sub i503 %old_r_value, %quotient_mul_new_r
  store i503 %sub_r_res, ptr %new_r, align 4
  br label %while

exit:                                             ; preds = %while
  %extended_a = sext i252 %0 to i503
  %inverse = load i503, ptr %t, align 4
  %res = mul i503 %extended_a, %inverse
  %res3 = call i252 @modulo(i503 %res)
  ret i252 %res3
}
```