### PR TITLE
fix(core): fix wrong pointee_ty when building GEP for struct_construct

### DIFF
--- a/core/src/sierra/corelib_functions/structs/construct.rs
+++ b/core/src/sierra/corelib_functions/structs/construct.rs
@@ -45,10 +45,9 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let struct_ptr = self.builder.build_alloca(return_type, "res_ptr");
         // Store each field in the struct.
         for (i, param) in func.get_params().iter().enumerate() {
-            let param_type = param.get_type();
             let tuple_ptr = self
                 .builder
-                .build_struct_gep(param_type, struct_ptr, i as u32, format!("field_{i}_ptr").as_str())
+                .build_struct_gep(return_type, struct_ptr, i as u32, format!("field_{i}_ptr").as_str())
                 .unwrap();
             self.builder.build_store(tuple_ptr, *param);
         }

--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -76,7 +76,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                             .expect("Call should have worked");
                         if res.is_struct_value()
                             && res.into_struct_value().get_type().count_fields() > 0
-                            && invocation.branches[0].results.len() > 1
+                            && !fn_name.starts_with("store_temp")
                         {
                             self.unpack_tuple(&invocation.branches[0].results, res.into_struct_value())
                         } else {

--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -77,6 +77,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                         if res.is_struct_value()
                             && res.into_struct_value().get_type().count_fields() > 0
                             && !fn_name.starts_with("store_temp")
+                            && !fn_name.starts_with("struct_construct")
                         {
                             self.unpack_tuple(&invocation.branches[0].results, res.into_struct_value())
                         } else {

--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -74,7 +74,10 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                             .try_as_basic_value()
                             .left()
                             .expect("Call should have worked");
-                        if res.is_struct_value() && res.into_struct_value().get_type().count_fields() > 0 {
+                        if res.is_struct_value()
+                            && res.into_struct_value().get_type().count_fields() > 0
+                            && invocation.branches[0].results.len() > 1
+                        {
                             self.unpack_tuple(&invocation.branches[0].results, res.into_struct_value())
                         } else {
                             self.variables.insert(invocation.branches[0].results[0].id.to_string(), res);

--- a/core/tests/sierra_to_llvm.rs
+++ b/core/tests/sierra_to_llvm.rs
@@ -15,6 +15,7 @@ macro_rules! test_resource_file {
 #[test_case("fib_main")]
 #[test_case("fib_box")]
 #[test_case("fib_box_main")]
+#[test_case("struct_construct")]
 fn compile_sierra_program_to_llvm(name: &str) {
     let program_path = test_resource_file!(format!("sierra/{}.sierra", name));
     let tmp_dir = TempDir::new("tmp").unwrap();

--- a/core/tests/sierra_to_llvm.rs
+++ b/core/tests/sierra_to_llvm.rs
@@ -21,7 +21,6 @@ fn compile_sierra_program_to_llvm(name: &str) {
     let tmp_dir = TempDir::new("tmp").unwrap();
     let llvm_output_path = tmp_dir.path().join("test.ll");
     let result = Compiler::compile_from_file(&program_path, &llvm_output_path, Some("x86_64-pc-linux-gnu"));
-    dbg!(&result);
     assert!(result.is_ok());
     let llvm_ir = std::fs::read_to_string(llvm_output_path).unwrap();
     let expected_llvm_ir = std::fs::read_to_string(test_resource_file!(format!("llvm/{}.ll", name))).unwrap();

--- a/core/tests/sierra_to_llvm.rs
+++ b/core/tests/sierra_to_llvm.rs
@@ -21,6 +21,7 @@ fn compile_sierra_program_to_llvm(name: &str) {
     let tmp_dir = TempDir::new("tmp").unwrap();
     let llvm_output_path = tmp_dir.path().join("test.ll");
     let result = Compiler::compile_from_file(&program_path, &llvm_output_path, Some("x86_64-pc-linux-gnu"));
+    dbg!(&result);
     assert!(result.is_ok());
     let llvm_ir = std::fs::read_to_string(llvm_output_path).unwrap();
     let expected_llvm_ir = std::fs::read_to_string(test_resource_file!(format!("llvm/{}.ll", name))).unwrap();

--- a/core/tests/test_data/cairo/struct_construct.cairo
+++ b/core/tests/test_data/cairo/struct_construct.cairo
@@ -1,0 +1,3 @@
+fn complex_type() -> (felt, felt) {
+    (2, 4)
+}

--- a/core/tests/test_data/llvm/struct_construct.ll
+++ b/core/tests/test_data/llvm/struct_construct.ll
@@ -1,0 +1,49 @@
+; ModuleID = 'root'
+source_filename = "root"
+target triple = "x86_64-pc-linux-gnu"
+
+define i252 @modulo(i503 %0) {
+entry:
+  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i503 %modulus to i252
+  ret i252 %res
+}
+
+define i252 @"felt_const<2>"() {
+entry:
+  ret i252 2
+}
+
+define i252 @"felt_const<4>"() {
+entry:
+  ret i252 4
+}
+
+define { i252, i252 } @"struct_construct<Tuple<felt, felt>>"(i252 %0, i252 %1) {
+entry:
+  %res_ptr = alloca { i252, i252 }, align 8
+  %field_0_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
+  store i252 %0, ptr %field_0_ptr, align 4
+  %field_1_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
+  store i252 %1, ptr %field_1_ptr, align 4
+  %res = load { i252, i252 }, ptr %res_ptr, align 4
+  ret { i252, i252 } %res
+}
+
+define { i252, i252 } @"store_temp<Tuple<felt, felt>>"({ i252, i252 } %0) {
+entry:
+  ret { i252, i252 } %0
+}
+
+define { { i252, i252 } } @"struct_construct::struct_construct::complex_type"() {
+entry:
+  %0 = call i252 @"felt_const<2>"()
+  %1 = call i252 @"felt_const<4>"()
+  %2 = call { i252, i252 } @"struct_construct<Tuple<felt, felt>>"(i252 %0, i252 %1)
+  %3 = call { i252, i252 } @"store_temp<Tuple<felt, felt>>"({ i252, i252 } %2)
+  %ret_struct_ptr = alloca { { i252, i252 } }, align 8
+  %field_0_ptr = getelementptr inbounds { { i252, i252 } }, ptr %ret_struct_ptr, i32 0, i32 0
+  store { i252, i252 } %3, ptr %field_0_ptr, align 4
+  %return_struct_value = load { { i252, i252 } }, ptr %ret_struct_ptr, align 4
+  ret { { i252, i252 } } %return_struct_value
+}

--- a/core/tests/test_data/sierra/struct_construct.sierra
+++ b/core/tests/test_data/sierra/struct_construct.sierra
@@ -1,0 +1,16 @@
+type felt = felt;
+type Tuple<felt, felt> = Struct<ut@Tuple, felt, felt>;
+
+libfunc felt_const<2> = felt_const<2>;
+libfunc felt_const<4> = felt_const<4>;
+libfunc struct_construct<Tuple<felt, felt>> = struct_construct<Tuple<felt, felt>>;
+libfunc store_temp<Tuple<felt, felt>> = store_temp<Tuple<felt, felt>>;
+
+felt_const<2>() -> ([0]);
+felt_const<4>() -> ([1]);
+struct_construct<Tuple<felt, felt>>([0], [1]) -> ([2]);
+store_temp<Tuple<felt, felt>>([2]) -> ([3]);
+return([3]);
+
+struct_construct::struct_construct::complex_type@0() -> (Tuple<felt, felt>);
+


### PR DESCRIPTION
The type passed when building the GEP for the struct is wrong, i noticed this when trying to make the fib counter example work, since previously all our programs used simple types when calling struct contruct we didn't notice it, but trying with 

```
type Tuple<felt, felt> = Struct<ut@Tuple, felt, felt>;

libfunc struct_construct<Tuple<felt, felt>> = struct_construct<Tuple<felt, felt>>;
```

would crash.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Crashes when contructing a struct with more than 1 type.

Issue Number: N/A

# What is the new behavior?

Constructs the struct correctly and doesn't crash.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

