### PR TITLE
fix(core): clear variables map on every func declaration instead of once

### DIFF
--- a/core/src/sierra/process/funcs.rs
+++ b/core/src/sierra/process/funcs.rs
@@ -20,11 +20,11 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Check that the current state is valid.
         self.check_state(&CompilationState::CoreLibFunctionsProcessed)?;
 
-        // Clear the variables map in case a previous function has been processed.
-        self.variables.clear();
-
         // Loop through the function declarations (last category of the sierra file).
         for func_declaration in self.program.funcs.iter() {
+            // Clear the variables map in case a previous function has been processed.
+            self.variables.clear();
+
             // Arguments of the function.
             let mut args = vec![];
             for Param { id: _, ty: ConcreteTypeId { id: type_id, debug_name: _debug_name } } in &func_declaration.params


### PR DESCRIPTION
The variables map should be cleared for each function declaration.

# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The variables map is only cleared once before function declarations are processed, leaving room for bugs.

Issue Number: N/A

# What is the new behavior?
The variables map is cleared once each function declaration starts

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

