### PR TITLE
feat(core): add print for arbitrary types

### DIFF
--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -6,6 +6,7 @@ use tracing::debug;
 
 use crate::sierra::errors::{CompilerResult, DEBUG_NAME_EXPECTED};
 use crate::sierra::llvm_compiler::Compiler;
+use crate::sierra::process::funcs::PRINT_RETURN;
 
 /// Implementation of the statement processing for the compiler.
 impl<'a, 'ctx> Compiler<'a, 'ctx> {
@@ -178,17 +179,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                             } else {
                                 // If there is something to return we print it (to keep the right main signature but
                                 // still see what happened).
-                                return_value = self
-                                    .builder
-                                    .build_call(
-                                        self.module
-                                            .get_function("print")
-                                            .expect("Print function should have been declared"),
-                                        &[return_value.into()],
-                                        "worked",
-                                    )
-                                    .try_as_basic_value()
-                                    .expect_left("Call should return a value");
+                                return_value = self.call_print(PRINT_RETURN, return_value.into());
                             }
                         }
                         // Return the specified value.

--- a/core/src/sierra/statements_processing/printf/mod.rs
+++ b/core/src/sierra/statements_processing/printf/mod.rs
@@ -1,24 +1,33 @@
 use inkwell::module::Linkage;
-use inkwell::types::StructType;
+use inkwell::types::BasicMetadataTypeEnum;
+use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum};
 use inkwell::AddressSpace;
 
 use crate::sierra::llvm_compiler::Compiler;
 
 impl<'a, 'ctx> Compiler<'a, 'ctx> {
-    /// Implementation of the LLVM IR wrapper for the printf function.
-    pub fn printf(&self, ty: StructType<'ctx>) {
+    /// Defines a function that wraps printf to print a value of type `ty`.
+    /// Useful for debugging.
+    pub fn printf_for_type(&self, ty: BasicMetadataTypeEnum<'ctx>, func_name: &str) {
         // declare i32 @printf(ptr, ...)
         // i8* is the str type
         let i8_type = self.context.i8_type();
-        let str_type = i8_type.ptr_type(AddressSpace::from(0));
+
         // return type of printf
         let i32_type = self.context.i32_type();
-        // Define llvm signature of printf
-        let printf_type = i32_type.fn_type(&[str_type.into()], true);
-        // Declare the function in the module.
-        let printfunc = self.module.add_function("printf", printf_type, Some(Linkage::External));
+
+        let printfunc = if let Some(printfunc) = self.module.get_function("printf") {
+            printfunc
+        } else {
+            let str_type = i8_type.ptr_type(AddressSpace::from(0));
+            // Define llvm signature of printf
+            let printf_type = i32_type.fn_type(&[str_type.into()], true);
+            // Declare the function in the module.
+            self.module.add_function("printf", printf_type, Some(Linkage::External))
+        };
+
         // Wrapper of printf to call it with the expected main return value.
-        let func = self.module.add_function("print", self.context.i32_type().fn_type(&[ty.into()], false), None);
+        let func = self.module.add_function(func_name, i32_type.fn_type(&[ty], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // printf format "%ld\n"
         let format_ptr = self.builder.build_alloca(i8_type.array_type(5), "prefix");
@@ -32,17 +41,32 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 i8_type.const_int(b'\0'.into(), false),
             ]),
         );
-        // Return if print has worked.
+        // Returns the number of characters printed (from printf).
         let res = self
             .builder
             .build_call(
                 printfunc,
                 &[format_ptr.into(), func.get_first_param().expect("Function should have exactly 1 param").into()],
-                "worked",
+                "printed_characters_n",
             )
             .try_as_basic_value()
             .left()
             .expect("Function should return exactly 1 value");
         self.builder.build_return(Some(&res));
+    }
+
+    /// Utility function to print a value.
+    /// Must have generated the function beforehand with `printf_for_type` for the value type.
+    pub fn call_print(&self, func_name: &str, value: BasicMetadataValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
+        self.builder
+            .build_call(
+                self.module
+                    .get_function(func_name)
+                    .unwrap_or_else(|| panic!("{func_name} function should be declared before making calls to it")),
+                &[value],
+                "worked",
+            )
+            .try_as_basic_value()
+            .expect_left("Call should return a value")
     }
 }

--- a/core/tests/test_data/llvm/addition.ll
+++ b/core/tests/test_data/llvm/addition.ll
@@ -41,12 +41,28 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print({ i252 } %0) {
+define i32 @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
   store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %worked
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_return({ i252 } %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
+  ret i32 %printed_characters_n
 }
 
 define i32 @main() {
@@ -61,6 +77,6 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %5, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print({ i252 } %return_struct_value)
+  %worked = call i32 @print_return({ i252 } %return_struct_value)
   ret i32 %worked
 }

--- a/core/tests/test_data/llvm/fib.ll
+++ b/core/tests/test_data/llvm/fib.ll
@@ -53,6 +53,24 @@ entry:
   ret i252 %0
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { i252 } @"fib::fib::fib"(i252 %0, i252 %1, i252 %2) {
 entry:
   %3 = call { i252, i252 } @"dup<felt>"(i252 %2)

--- a/core/tests/test_data/llvm/fib_bench.ll
+++ b/core/tests/test_data/llvm/fib_bench.ll
@@ -75,6 +75,24 @@ entry:
   ret {} %0
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { i252 } @"fib_caller::fib_caller::fib"(i252 %0, i252 %1, i252 %2) {
 entry:
   %3 = call { i252, i252 } @"dup<felt>"(i252 %2)
@@ -133,14 +151,12 @@ dest4:                                            ; preds = %dest1
   ret { i252 } %return_struct_value7
 }
 
-declare i32 @printf(ptr, ...)
-
-define i32 @print({ {} } %0) {
+define i32 @print_return({ {} } %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
   store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { {} } %0)
-  ret i32 %worked
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { {} } %0)
+  ret i32 %printed_characters_n
 }
 
 define i32 @main(i252 %0) {

--- a/core/tests/test_data/llvm/fib_box.ll
+++ b/core/tests/test_data/llvm/fib_box.ll
@@ -79,6 +79,24 @@ entry:
   ret i252 %0
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { i252 } @"fib_box::fib_box::fib"(i252 %0, i252 %1, i252 %2) {
 entry:
   %3 = call i252 @"unbox<felt>"(i252 %2)

--- a/core/tests/test_data/llvm/fib_box_main.ll
+++ b/core/tests/test_data/llvm/fib_box_main.ll
@@ -89,6 +89,24 @@ entry:
   ret i252 30
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { i252 } @"fib_box::fib_box::fib"(i252 %0, i252 %1, i252 %2) {
 entry:
   %3 = call i252 @"unbox<felt>"(i252 %2)
@@ -157,14 +175,12 @@ dest4:                                            ; preds = %dest1
   ret { i252 } %return_struct_value7
 }
 
-declare i32 @printf(ptr, ...)
-
-define i32 @print({ i252 } %0) {
+define i32 @print_return({ i252 } %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
   store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %worked
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
+  ret i32 %printed_characters_n
 }
 
 define i32 @main() {
@@ -192,6 +208,6 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %14, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print({ i252 } %return_struct_value)
+  %worked = call i32 @print_return({ i252 } %return_struct_value)
   ret i32 %worked
 }

--- a/core/tests/test_data/llvm/fib_main.ll
+++ b/core/tests/test_data/llvm/fib_main.ll
@@ -63,6 +63,24 @@ entry:
   ret i252 30
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { i252 } @"fib_caller::fib_caller::fib"(i252 %0, i252 %1, i252 %2) {
 entry:
   %3 = call { i252, i252 } @"dup<felt>"(i252 %2)
@@ -121,14 +139,12 @@ dest4:                                            ; preds = %dest1
   ret { i252 } %return_struct_value7
 }
 
-declare i32 @printf(ptr, ...)
-
-define i32 @print({ i252 } %0) {
+define i32 @print_return({ i252 } %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
   store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %worked
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
+  ret i32 %printed_characters_n
 }
 
 define i32 @main(i252 %0) {
@@ -149,6 +165,6 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %8, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print({ i252 } %return_struct_value)
+  %worked = call i32 @print_return({ i252 } %return_struct_value)
   ret i32 %worked
 }

--- a/core/tests/test_data/llvm/struct_construct.ll
+++ b/core/tests/test_data/llvm/struct_construct.ll
@@ -35,6 +35,24 @@ entry:
   ret { i252, i252 } %0
 }
 
+declare i32 @printf(ptr, ...)
+
+define i32 @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
 define { { i252, i252 } } @"struct_construct::struct_construct::complex_type"() {
 entry:
   %0 = call i252 @"felt_const<2>"()

--- a/examples/program.ll
+++ b/examples/program.ll
@@ -40,12 +40,28 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print({ i252 } %0) {
+define i32 @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
   store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %worked = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %worked
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
+  ret i32 %printed_characters_n
+}
+
+define i32 @print_return({ i252 } %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
+  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
+  ret i32 %printed_characters_n
 }
 
 define i32 @main() {
@@ -60,6 +76,6 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %5, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print({ i252 } %return_struct_value)
+  %worked = call i32 @print_return({ i252 } %return_struct_value)
   ret i32 %worked
 }


### PR DESCRIPTION
This pr modifies the current print so it can be used more easily.

It also adds a utility function to call a previously defined print more easily.

I also made it define 2 print functions for now, print_felt and print_double_felt, which I think will be useful to debug in this early stage of development.
With them you can call `self.call_print(PRINT_FELT, felt_value);` to easily print a felt (like we do on the main return value now).

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
