### PR TITLE
fix(core): fix print for big values, by printing it in hex form

### DIFF
--- a/core/src/sierra/process/funcs.rs
+++ b/core/src/sierra/process/funcs.rs
@@ -63,8 +63,13 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             // main function)
             let func_name = func_declaration.id.debug_name.clone().expect(DEBUG_NAME_EXPECTED).to_string();
             let func = if let Some(ret_ty) = return_type && func_name.ends_with("::main") {
-                // Generate the print function for the return value type.
-                self.printf_for_type(ret_ty.into(), PRINT_RETURN);
+                // Generate the print function for the return value type. (if there is 1, and its a int value type).
+                if ret_ty.count_fields() > 0 {
+                    let field = ret_ty.get_field_type_at_index(0).unwrap();
+                    if field.is_int_type() {
+                        self.printf_for_type(field.into(), PRINT_RETURN);
+                    }
+                }
                 self.module.add_function("main", self.context.i32_type().fn_type(args_metadata, false), None)
             } else {
                 self.module.add_function(

--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -179,7 +179,14 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                             } else {
                                 // If there is something to return we print it (to keep the right main signature but
                                 // still see what happened).
-                                return_value = self.call_print(PRINT_RETURN, return_value.into());
+                                let field_value_ptr = self
+                                    .builder
+                                    .build_struct_gep(return_struct_type, return_struct_ptr, 0, "return_value_ptr")
+                                    .unwrap();
+                                let field_value =
+                                    self.builder.build_load(field_ret_type, field_value_ptr, "return_value");
+                                self.call_print(PRINT_RETURN, field_value.into());
+                                return_value = self.context.i32_type().const_int(0, false).into();
                             }
                         }
                         // Return the specified value.

--- a/core/src/sierra/statements_processing/printf/mod.rs
+++ b/core/src/sierra/statements_processing/printf/mod.rs
@@ -1,6 +1,6 @@
 use inkwell::module::Linkage;
 use inkwell::types::BasicMetadataTypeEnum;
-use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum};
+use inkwell::values::{BasicMetadataValueEnum, BasicValue};
 use inkwell::AddressSpace;
 
 use crate::sierra::llvm_compiler::Compiler;
@@ -16,6 +16,8 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // return type of printf
         let i32_type = self.context.i32_type();
 
+        let void_type = self.context.void_type();
+
         let printfunc = if let Some(printfunc) = self.module.get_function("printf") {
             printfunc
         } else {
@@ -27,7 +29,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         };
 
         // Wrapper of printf to call it with the expected main return value.
-        let func = self.module.add_function(func_name, i32_type.fn_type(&[ty], false), None);
+        let func = self.module.add_function(func_name, void_type.fn_type(&[ty], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // printf format "%ld\n"
         let format_ptr = self.builder.build_alloca(i8_type.array_type(5), "prefix");
@@ -35,38 +37,68 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             format_ptr,
             self.context.i8_type().const_array(&[
                 i8_type.const_int(b'%'.into(), false),
-                i8_type.const_int(b'l'.into(), false),
-                i8_type.const_int(b'd'.into(), false),
-                i8_type.const_int(b'\n'.into(), false),
+                i8_type.const_int(b'0'.into(), false),
+                i8_type.const_int(b'8'.into(), false),
+                i8_type.const_int(b'X'.into(), false),
                 i8_type.const_int(b'\0'.into(), false),
             ]),
         );
-        // Returns the number of characters printed (from printf).
-        let res = self
-            .builder
-            .build_call(
-                printfunc,
-                &[format_ptr.into(), func.get_first_param().expect("Function should have exactly 1 param").into()],
-                "printed_characters_n",
-            )
+
+        // For now we only allow printing int types.
+        let value = func.get_first_param().expect("Function should have exactly 1 param").into_int_value();
+        let rounded_type = self.context.custom_width_int_type(round_up(value.get_type().get_bit_width()));
+        let value = self.builder.build_int_s_extend(value, rounded_type, "rounded_size_val");
+        let mut bit_width = value.get_type().get_bit_width();
+
+        while bit_width > 0 {
+            let shift_by = value.get_type().const_int(bit_width.saturating_sub(32).into(), false);
+            let temp_value = self.builder.build_right_shift(value, shift_by, false, "shifted");
+            let trunc = self.builder.build_int_cast(temp_value, self.context.i32_type(), "print_value_trunc");
+
+            self.builder
+                .build_call(printfunc, &[format_ptr.into(), trunc.as_basic_value_enum().into()], "printed_chars")
+                .try_as_basic_value()
+                .left()
+                .expect("Function should return exactly 1 value");
+            bit_width = bit_width.saturating_sub(32);
+        }
+
+        // Print the new line.
+        let format_ptr = self.builder.build_alloca(i8_type.array_type(2), "prefix_newline");
+        self.builder.build_store(
+            format_ptr,
+            self.context
+                .i8_type()
+                .const_array(&[i8_type.const_int(b'\n'.into(), false), i8_type.const_int(b'\0'.into(), false)]),
+        );
+        self.builder
+            .build_call(printfunc, &[format_ptr.into()], "printed_chars")
             .try_as_basic_value()
             .left()
             .expect("Function should return exactly 1 value");
-        self.builder.build_return(Some(&res));
+
+        self.builder.build_return(None);
     }
 
     /// Utility function to print a value.
     /// Must have generated the function beforehand with `printf_for_type` for the value type.
-    pub fn call_print(&self, func_name: &str, value: BasicMetadataValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
-        self.builder
-            .build_call(
-                self.module
-                    .get_function(func_name)
-                    .unwrap_or_else(|| panic!("{func_name} function should be declared before making calls to it")),
-                &[value],
-                "worked",
-            )
-            .try_as_basic_value()
-            .expect_left("Call should return a value")
+    pub fn call_print(&self, func_name: &str, value: BasicMetadataValueEnum<'ctx>) {
+        self.builder.build_call(
+            self.module
+                .get_function(func_name)
+                .unwrap_or_else(|| panic!("{func_name} function should be declared before making calls to it")),
+            &[value],
+            "worked",
+        );
     }
+}
+
+/// rounds to the nearest power of 2 up.
+#[inline]
+const fn round_up(value: u32) -> u32 {
+    let mut power = 1;
+    while power < value {
+        power *= 2;
+    }
+    power
 }

--- a/core/tests/test_data/llvm/addition.ll
+++ b/core/tests/test_data/llvm/addition.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i252 @"felt_const<1>"() {
@@ -57,12 +135,39 @@ entry:
   ret i252 %0
 }
 
-define i32 @print_return({ i252 } %0) {
+define void @print_return(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i32 @main() {
@@ -77,6 +182,8 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %5, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print_return({ i252 } %return_struct_value)
-  ret i32 %worked
+  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i252, ptr %return_value_ptr, align 4
+  call void @print_return(i252 %return_value)
+  ret i32 0
 }

--- a/core/tests/test_data/llvm/fib.ll
+++ b/core/tests/test_data/llvm/fib.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define { i252, i252 } @"dup<felt>"(i252 %0) {

--- a/core/tests/test_data/llvm/fib_bench.ll
+++ b/core/tests/test_data/llvm/fib_bench.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define { i252, i252 } @"dup<felt>"(i252 %0) {
@@ -149,14 +227,6 @@ dest4:                                            ; preds = %dest1
   store i252 %15, ptr %field_0_ptr6, align 4
   %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
   ret { i252 } %return_struct_value7
-}
-
-define i32 @print_return({ {} } %0) {
-entry:
-  %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { {} } %0)
-  ret i32 %printed_characters_n
 }
 
 define i32 @main(i252 %0) {

--- a/core/tests/test_data/llvm/fib_box.ll
+++ b/core/tests/test_data/llvm/fib_box.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i252 @"unbox<felt>"(i252 %0) {

--- a/core/tests/test_data/llvm/fib_box_main.ll
+++ b/core/tests/test_data/llvm/fib_box_main.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i252 @"unbox<felt>"(i252 %0) {
@@ -175,12 +253,39 @@ dest4:                                            ; preds = %dest1
   ret { i252 } %return_struct_value7
 }
 
-define i32 @print_return({ i252 } %0) {
+define void @print_return(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i32 @main() {
@@ -208,6 +313,8 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %14, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print_return({ i252 } %return_struct_value)
-  ret i32 %worked
+  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i252, ptr %return_value_ptr, align 4
+  call void @print_return(i252 %return_value)
+  ret i32 0
 }

--- a/core/tests/test_data/llvm/fib_main.ll
+++ b/core/tests/test_data/llvm/fib_main.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define { i252, i252 } @"dup<felt>"(i252 %0) {
@@ -139,12 +217,39 @@ dest4:                                            ; preds = %dest1
   ret { i252 } %return_struct_value7
 }
 
-define i32 @print_return({ i252 } %0) {
+define void @print_return(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i32 @main(i252 %0) {
@@ -165,6 +270,8 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %8, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print_return({ i252 } %return_struct_value)
-  ret i32 %worked
+  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i252, ptr %return_value_ptr, align 4
+  call void @print_return(i252 %return_value)
+  ret i32 0
 }

--- a/core/tests/test_data/llvm/struct_construct.ll
+++ b/core/tests/test_data/llvm/struct_construct.ll
@@ -11,20 +11,98 @@ entry:
 
 declare i32 @printf(ptr, ...)
 
-define i32 @print_felt(i252 %0) {
+define void @print_felt(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
-define i32 @print_double_felt(i503 %0) {
+define void @print_double_felt(i503 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i252 @"felt_const<2>"() {

--- a/examples/program.ll
+++ b/examples/program.ll
@@ -8,6 +8,102 @@ entry:
   ret i252 %res
 }
 
+declare i32 @printf(ptr, ...)
+
+define void @print_felt(i252 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
+}
+
+define void @print_double_felt(i503 %0) {
+entry:
+  %prefix = alloca [5 x i8], align 1
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i503 %0 to i512
+  %shifted = lshr i512 %rounded_size_val, 480
+  %print_value_trunc = trunc i512 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i512 %rounded_size_val, 448
+  %print_value_trunc2 = trunc i512 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i512 %rounded_size_val, 416
+  %print_value_trunc5 = trunc i512 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i512 %rounded_size_val, 384
+  %print_value_trunc8 = trunc i512 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i512 %rounded_size_val, 352
+  %print_value_trunc11 = trunc i512 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i512 %rounded_size_val, 320
+  %print_value_trunc14 = trunc i512 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i512 %rounded_size_val, 288
+  %print_value_trunc17 = trunc i512 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i512 %rounded_size_val, 256
+  %print_value_trunc20 = trunc i512 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %shifted22 = lshr i512 %rounded_size_val, 224
+  %print_value_trunc23 = trunc i512 %shifted22 to i32
+  %printed_chars24 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc23)
+  %shifted25 = lshr i512 %rounded_size_val, 192
+  %print_value_trunc26 = trunc i512 %shifted25 to i32
+  %printed_chars27 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc26)
+  %shifted28 = lshr i512 %rounded_size_val, 160
+  %print_value_trunc29 = trunc i512 %shifted28 to i32
+  %printed_chars30 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc29)
+  %shifted31 = lshr i512 %rounded_size_val, 128
+  %print_value_trunc32 = trunc i512 %shifted31 to i32
+  %printed_chars33 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc32)
+  %shifted34 = lshr i512 %rounded_size_val, 96
+  %print_value_trunc35 = trunc i512 %shifted34 to i32
+  %printed_chars36 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc35)
+  %shifted37 = lshr i512 %rounded_size_val, 64
+  %print_value_trunc38 = trunc i512 %shifted37 to i32
+  %printed_chars39 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc38)
+  %shifted40 = lshr i512 %rounded_size_val, 32
+  %print_value_trunc41 = trunc i512 %shifted40 to i32
+  %printed_chars42 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc41)
+  %shifted43 = lshr i512 %rounded_size_val, 0
+  %print_value_trunc44 = trunc i512 %shifted43 to i32
+  %printed_chars45 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc44)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars46 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
+}
+
 define i252 @"felt_const<1>"() {
 entry:
   ret i252 1
@@ -38,30 +134,39 @@ entry:
   ret i252 %0
 }
 
-declare i32 @printf(ptr, ...)
-
-define i32 @print_felt(i252 %0) {
+define void @print_return(i252 %0) {
 entry:
   %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i252 %0)
-  ret i32 %printed_characters_n
-}
-
-define i32 @print_double_felt(i503 %0) {
-entry:
-  %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, i503 %0)
-  ret i32 %printed_characters_n
-}
-
-define i32 @print_return({ i252 } %0) {
-entry:
-  %prefix = alloca [5 x i8], align 1
-  store [5 x i8] c"%ld\0A\00", ptr %prefix, align 1
-  %printed_characters_n = call i32 (ptr, ...) @printf(ptr %prefix, { i252 } %0)
-  ret i32 %printed_characters_n
+  store [5 x i8] c"%08X\00", ptr %prefix, align 1
+  %rounded_size_val = sext i252 %0 to i256
+  %shifted = lshr i256 %rounded_size_val, 224
+  %print_value_trunc = trunc i256 %shifted to i32
+  %printed_chars = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc)
+  %shifted1 = lshr i256 %rounded_size_val, 192
+  %print_value_trunc2 = trunc i256 %shifted1 to i32
+  %printed_chars3 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc2)
+  %shifted4 = lshr i256 %rounded_size_val, 160
+  %print_value_trunc5 = trunc i256 %shifted4 to i32
+  %printed_chars6 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc5)
+  %shifted7 = lshr i256 %rounded_size_val, 128
+  %print_value_trunc8 = trunc i256 %shifted7 to i32
+  %printed_chars9 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc8)
+  %shifted10 = lshr i256 %rounded_size_val, 96
+  %print_value_trunc11 = trunc i256 %shifted10 to i32
+  %printed_chars12 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc11)
+  %shifted13 = lshr i256 %rounded_size_val, 64
+  %print_value_trunc14 = trunc i256 %shifted13 to i32
+  %printed_chars15 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc14)
+  %shifted16 = lshr i256 %rounded_size_val, 32
+  %print_value_trunc17 = trunc i256 %shifted16 to i32
+  %printed_chars18 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc17)
+  %shifted19 = lshr i256 %rounded_size_val, 0
+  %print_value_trunc20 = trunc i256 %shifted19 to i32
+  %printed_chars21 = call i32 (ptr, ...) @printf(ptr %prefix, i32 %print_value_trunc20)
+  %prefix_newline = alloca [2 x i8], align 1
+  store [2 x i8] c"\0A\00", ptr %prefix_newline, align 1
+  %printed_chars22 = call i32 (ptr, ...) @printf(ptr %prefix_newline)
+  ret void
 }
 
 define i32 @main() {
@@ -76,6 +181,8 @@ entry:
   %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
   store i252 %5, ptr %field_0_ptr, align 4
   %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %worked = call i32 @print_return({ i252 } %return_struct_value)
-  ret i32 %worked
+  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i252, ptr %return_value_ptr, align 4
+  call void @print_return(i252 %return_value)
+  ret i32 0
 }


### PR DESCRIPTION
The generated printf now prints the numbers in hex form, and it now works correctly for sizes bigger than 32bits.

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The print call shows incorrect values for integers with a value bigger than the 32bit max.

Issue Number: N/A

# What is the new behavior?

Correctly prints big int values.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No


