### PR TITLE
Fix felt llvm size

### DIFF
--- a/core/src/sierra/corelib_functions/math/modulo.rs
+++ b/core/src/sierra/corelib_functions/math/modulo.rs
@@ -13,7 +13,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.get_type_from_name("felt").expect("Can't get felt from name");
         // Max size of felt operation (Prime - 1 ) * ( Prime - 1) = 503 bits number
-        let big_felt_type = self.context.custom_width_int_type(503);
+        let big_felt_type = self.context.custom_width_int_type(512);
         // fn felt_modulo(a: double_felt) -> felt
         let func = self.module.add_function("modulo", felt_type.fn_type(&[big_felt_type.into()], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));

--- a/core/src/sierra/corelib_functions/math/mul.rs
+++ b/core/src/sierra/corelib_functions/math/mul.rs
@@ -26,7 +26,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         );
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // The maximum value of a multiplication is (prime - 1)² which is 503 bits.
-        let double_felt = self.context.custom_width_int_type(503);
+        let double_felt = self.context.custom_width_int_type(512);
         // Extend left hand side.
         // We just defined the function so it shouldn't panic
         let lhs = self.builder.build_int_s_extend(

--- a/core/src/sierra/corelib_functions/math/sub.rs
+++ b/core/src/sierra/corelib_functions/math/sub.rs
@@ -33,7 +33,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             func.get_last_param().unwrap().into_int_value(),
             "res",
         );
-        let arg = self.builder.build_int_s_extend(sub, self.context.custom_width_int_type(503), "arg");
+        let arg = self.builder.build_int_s_extend(sub, self.context.custom_width_int_type(512), "arg");
         let res = self
             .builder
             .build_call(

--- a/core/src/sierra/process/corelib.rs
+++ b/core/src/sierra/process/corelib.rs
@@ -21,7 +21,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Check that the current state is valid.
         self.check_state(&CompilationState::TypesProcessed)?;
-        self.modulo();
 
         // Define external printf, used in call_printf calls.
         // i32 @printf(ptr, ...);
@@ -36,8 +35,9 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Should probably be removed in the future.
         let felt_type = self.get_type_from_name("felt").expect("Can't get felt from name");
         self.printf_for_type(felt_type.into(), PRINT_FELT_FUNC);
-        let double_felt = self.context.custom_width_int_type(503);
+        let double_felt = self.context.custom_width_int_type(512);
         self.printf_for_type(double_felt.into(), PRINT_DOUBLE_FELT_FUNC);
+        self.modulo();
 
         // Iterate over the libfunc declarations in the Sierra program.
         for libfunc_declaration in self.program.libfunc_declarations.iter() {

--- a/core/src/sierra/types/felt.rs
+++ b/core/src/sierra/types/felt.rs
@@ -8,7 +8,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         self.id_from_name.insert("felt".to_owned(), type_declaration.id.id.to_string());
         self.types.insert(
             type_declaration.id.id.to_string(),
-            Box::new(self.context.custom_width_int_type(252).as_basic_type_enum()),
+            Box::new(self.context.custom_width_int_type(253).as_basic_type_enum()),
         );
     }
 }

--- a/core/tests/test_data/llvm/addition.ll
+++ b/core/tests/test_data/llvm/addition.ll
@@ -2,227 +2,225 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @modulo(i512 %0) {
 entry:
-  ret i252 1
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"felt_const<2>"() {
+define i253 @"felt_const<1>"() {
 entry:
-  ret i252 2
+  ret i253 1
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define i253 @"felt_const<2>"() {
 entry:
-  ret i252 %0
+  ret i253 2
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 %0
 }
 
-define i252 @"rename<felt>"(i252 %0) {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define void @print_return(i252 %0) {
+define i253 @"rename<felt>"(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  ret i253 %0
+}
+
+define void @print_return(i253 %0) {
+entry:
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
@@ -230,21 +228,21 @@ entry:
 
 define i32 @main() {
 entry:
-  %0 = call i252 @"felt_const<1>"()
-  %1 = call i252 @"felt_const<2>"()
-  %2 = call i252 @"store_temp<felt>"(i252 %0)
-  %3 = call i252 @felt_add(i252 %2, i252 %1)
-  %4 = call i252 @"store_temp<felt>"(i252 %3)
-  %5 = call i252 @"rename<felt>"(i252 %4)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %5, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  %return_value = load i252, ptr %return_value_ptr, align 4
-  %format = alloca [14 x i8], align 1
+  %0 = call i253 @"felt_const<1>"()
+  %1 = call i253 @"felt_const<2>"()
+  %2 = call i253 @"store_temp<felt>"(i253 %0)
+  %3 = call i253 @felt_add(i253 %2, i253 %1)
+  %4 = call i253 @"store_temp<felt>"(i253 %3)
+  %5 = call i253 @"rename<felt>"(i253 %4)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %5, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  %return_value_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i253, ptr %return_value_ptr, align 4
+  %format = alloca [15 x i8], align 1
   store [15 x i8] c"Return value: \00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format)
-  call void @print_return(i252 %return_value)
+  call void @print_return(i253 %return_value)
   ret i32 0
 }

--- a/core/tests/test_data/llvm/fib.ll
+++ b/core/tests/test_data/llvm/fib.ll
@@ -2,253 +2,251 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define { i252, i252 } @"dup<felt>"(i252 %0) {
+define i253 @modulo(i512 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define { i253, i253 } @"dup<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 %0
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 1
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define i252 @felt_sub(i252 %0, i252 %1) {
+define i253 @"felt_const<1>"() {
 entry:
-  %res = sub i252 %0, %1
-  %arg = sext i252 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 1
 }
 
-define i252 @"rename<felt>"(i252 %0) {
+define i253 @felt_sub(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %res = sub i253 %0, %1
+  %arg = sext i253 %res to i512
+  %res1 = call i253 @modulo(i512 %arg)
+  ret i253 %res1
 }
 
-define { i252 } @"fib::fib::fib"(i252 %0, i252 %1, i252 %2) {
+define i253 @"rename<felt>"(i253 %0) {
 entry:
-  %3 = call { i252, i252 } @"dup<felt>"(i252 %2)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %3, ptr %res_ptr, align 4
-  %"2_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"2" = load i252, ptr %"2_ptr", align 4
-  %"3_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"3" = load i252, ptr %"3_ptr", align 4
-  %check = icmp eq i252 %"3", 0
+  ret i253 %0
+}
+
+define { i253 } @"fib::fib::fib"(i253 %0, i253 %1, i253 %2) {
+entry:
+  %3 = call { i253, i253 } @"dup<felt>"(i253 %2)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %3, ptr %res_ptr, align 4
+  %"2_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"2" = load i253, ptr %"2_ptr", align 4
+  %"3_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"3" = load i253, ptr %"3_ptr", align 4
+  %check = icmp eq i253 %"3", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
-  %4 = call i252 @"store_temp<felt>"(i252 %0)
+  %4 = call i253 @"store_temp<felt>"(i253 %0)
   br label %dest
 
 else:                                             ; preds = %entry
   br label %dest1
 
 dest:                                             ; preds = %then
-  %5 = call i252 @"rename<felt>"(i252 %4)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %5, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  ret { i252 } %return_struct_value
+  %5 = call i253 @"rename<felt>"(i253 %4)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %5, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  ret { i253 } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %6 = call { i252, i252 } @"dup<felt>"(i252 %1)
-  %res_ptr2 = alloca { i252, i252 }, align 8
-  store { i252, i252 } %6, ptr %res_ptr2, align 4
-  %"1_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"1" = load i252, ptr %"1_ptr", align 4
-  %"7_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 1
-  %"7" = load i252, ptr %"7_ptr", align 4
-  %7 = call i252 @felt_add(i252 %0, i252 %"7")
-  %8 = call i252 @"felt_const<1>"()
-  %9 = call i252 @felt_sub(i252 %"2", i252 %8)
-  %10 = call i252 @"store_temp<felt>"(i252 %"1")
-  %11 = call i252 @"store_temp<felt>"(i252 %7)
-  %12 = call i252 @"rename<felt>"(i252 %11)
-  %13 = call i252 @"store_temp<felt>"(i252 %9)
-  %14 = call i252 @"rename<felt>"(i252 %13)
-  %15 = call { i252 } @"fib::fib::fib"(i252 %10, i252 %12, i252 %14)
-  %res_ptr3 = alloca { i252 }, align 8
-  store { i252 } %15, ptr %res_ptr3, align 4
-  %"10_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr3, i32 0, i32 0
-  %"10" = load i252, ptr %"10_ptr", align 4
-  %16 = call i252 @"rename<felt>"(i252 %"10")
+  %6 = call { i253, i253 } @"dup<felt>"(i253 %1)
+  %res_ptr2 = alloca { i253, i253 }, align 8
+  store { i253, i253 } %6, ptr %res_ptr2, align 4
+  %"1_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"1" = load i253, ptr %"1_ptr", align 4
+  %"7_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 1
+  %"7" = load i253, ptr %"7_ptr", align 4
+  %7 = call i253 @felt_add(i253 %0, i253 %"7")
+  %8 = call i253 @"felt_const<1>"()
+  %9 = call i253 @felt_sub(i253 %"2", i253 %8)
+  %10 = call i253 @"store_temp<felt>"(i253 %"1")
+  %11 = call i253 @"store_temp<felt>"(i253 %7)
+  %12 = call i253 @"rename<felt>"(i253 %11)
+  %13 = call i253 @"store_temp<felt>"(i253 %9)
+  %14 = call i253 @"rename<felt>"(i253 %13)
+  %15 = call { i253 } @"fib::fib::fib"(i253 %10, i253 %12, i253 %14)
+  %res_ptr3 = alloca { i253 }, align 8
+  store { i253 } %15, ptr %res_ptr3, align 4
+  %"10_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr3, i32 0, i32 0
+  %"10" = load i253, ptr %"10_ptr", align 4
+  %16 = call i253 @"rename<felt>"(i253 %"10")
   br label %dest4
 
 dest4:                                            ; preds = %dest1
-  %17 = call i252 @"rename<felt>"(i252 %16)
-  %ret_struct_ptr5 = alloca { i252 }, align 8
-  %field_0_ptr6 = getelementptr inbounds { i252 }, ptr %ret_struct_ptr5, i32 0, i32 0
-  store i252 %17, ptr %field_0_ptr6, align 4
-  %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
-  ret { i252 } %return_struct_value7
+  %17 = call i253 @"rename<felt>"(i253 %16)
+  %ret_struct_ptr5 = alloca { i253 }, align 8
+  %field_0_ptr6 = getelementptr inbounds { i253 }, ptr %ret_struct_ptr5, i32 0, i32 0
+  store i253 %17, ptr %field_0_ptr6, align 4
+  %return_struct_value7 = load { i253 }, ptr %ret_struct_ptr5, align 4
+  ret { i253 } %return_struct_value7
 }

--- a/core/tests/test_data/llvm/fib_bench.ll
+++ b/core/tests/test_data/llvm/fib_bench.ll
@@ -2,205 +2,203 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define { i252, i252 } @"dup<felt>"(i252 %0) {
+define i253 @modulo(i512 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define { i253, i253 } @"dup<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 %0
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 1
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define i252 @felt_sub(i252 %0, i252 %1) {
+define i253 @"felt_const<1>"() {
 entry:
-  %res = sub i252 %0, %1
-  %arg = sext i252 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 1
 }
 
-define i252 @"rename<felt>"(i252 %0) {
+define i253 @felt_sub(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %res = sub i253 %0, %1
+  %arg = sext i253 %res to i512
+  %res1 = call i253 @modulo(i512 %arg)
+  ret i253 %res1
 }
 
-define i252 @"felt_const<0>"() {
+define i253 @"rename<felt>"(i253 %0) {
 entry:
-  ret i252 0
+  ret i253 %0
 }
 
-define i252 @"felt_const<500>"() {
+define i253 @"felt_const<0>"() {
 entry:
-  ret i252 500
+  ret i253 0
+}
+
+define i253 @"felt_const<500>"() {
+entry:
+  ret i253 500
 }
 
 define {} @"struct_construct<Unit>"() {
@@ -215,79 +213,79 @@ entry:
   ret {} %0
 }
 
-define i252 @"felt_const<100>"() {
+define i253 @"felt_const<100>"() {
 entry:
-  ret i252 100
+  ret i253 100
 }
 
-define { i252 } @"fib_caller::fib_caller::fib"(i252 %0, i252 %1, i252 %2) {
+define { i253 } @"fib_bench::fib_bench::fib"(i253 %0, i253 %1, i253 %2) {
 entry:
-  %3 = call { i252, i252 } @"dup<felt>"(i252 %2)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %3, ptr %res_ptr, align 4
-  %"2_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"2" = load i252, ptr %"2_ptr", align 4
-  %"4_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"4" = load i252, ptr %"4_ptr", align 4
-  %check = icmp eq i252 %"4", 0
+  %3 = call { i253, i253 } @"dup<felt>"(i253 %2)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %3, ptr %res_ptr, align 4
+  %"2_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"2" = load i253, ptr %"2_ptr", align 4
+  %"4_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"4" = load i253, ptr %"4_ptr", align 4
+  %check = icmp eq i253 %"4", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
-  %4 = call i252 @"store_temp<felt>"(i252 %0)
+  %4 = call i253 @"store_temp<felt>"(i253 %0)
   br label %dest
 
 else:                                             ; preds = %entry
   br label %dest1
 
 dest:                                             ; preds = %then
-  %5 = call i252 @"rename<felt>"(i252 %4)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %5, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  ret { i252 } %return_struct_value
+  %5 = call i253 @"rename<felt>"(i253 %4)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %5, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  ret { i253 } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %6 = call { i252, i252 } @"dup<felt>"(i252 %1)
-  %res_ptr2 = alloca { i252, i252 }, align 8
-  store { i252, i252 } %6, ptr %res_ptr2, align 4
-  %"1_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"1" = load i252, ptr %"1_ptr", align 4
-  %"7_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 1
-  %"7" = load i252, ptr %"7_ptr", align 4
-  %7 = call i252 @felt_add(i252 %0, i252 %"7")
-  %8 = call i252 @"felt_const<1>"()
-  %9 = call i252 @felt_sub(i252 %"2", i252 %8)
-  %10 = call i252 @"store_temp<felt>"(i252 %"1")
-  %11 = call i252 @"store_temp<felt>"(i252 %7)
-  %12 = call i252 @"store_temp<felt>"(i252 %9)
-  %13 = call { i252 } @"fib_caller::fib_caller::fib"(i252 %10, i252 %11, i252 %12)
-  %res_ptr3 = alloca { i252 }, align 8
-  store { i252 } %13, ptr %res_ptr3, align 4
-  %"10_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr3, i32 0, i32 0
-  %"10" = load i252, ptr %"10_ptr", align 4
-  %14 = call i252 @"rename<felt>"(i252 %"10")
+  %6 = call { i253, i253 } @"dup<felt>"(i253 %1)
+  %res_ptr2 = alloca { i253, i253 }, align 8
+  store { i253, i253 } %6, ptr %res_ptr2, align 4
+  %"1_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"1" = load i253, ptr %"1_ptr", align 4
+  %"7_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 1
+  %"7" = load i253, ptr %"7_ptr", align 4
+  %7 = call i253 @felt_add(i253 %0, i253 %"7")
+  %8 = call i253 @"felt_const<1>"()
+  %9 = call i253 @felt_sub(i253 %"2", i253 %8)
+  %10 = call i253 @"store_temp<felt>"(i253 %"1")
+  %11 = call i253 @"store_temp<felt>"(i253 %7)
+  %12 = call i253 @"store_temp<felt>"(i253 %9)
+  %13 = call { i253 } @"fib_bench::fib_bench::fib"(i253 %10, i253 %11, i253 %12)
+  %res_ptr3 = alloca { i253 }, align 8
+  store { i253 } %13, ptr %res_ptr3, align 4
+  %"10_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr3, i32 0, i32 0
+  %"10" = load i253, ptr %"10_ptr", align 4
+  %14 = call i253 @"rename<felt>"(i253 %"10")
   br label %dest4
 
 dest4:                                            ; preds = %dest1
-  %15 = call i252 @"rename<felt>"(i252 %14)
-  %ret_struct_ptr5 = alloca { i252 }, align 8
-  %field_0_ptr6 = getelementptr inbounds { i252 }, ptr %ret_struct_ptr5, i32 0, i32 0
-  store i252 %15, ptr %field_0_ptr6, align 4
-  %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
-  ret { i252 } %return_struct_value7
+  %15 = call i253 @"rename<felt>"(i253 %14)
+  %ret_struct_ptr5 = alloca { i253 }, align 8
+  %field_0_ptr6 = getelementptr inbounds { i253 }, ptr %ret_struct_ptr5, i32 0, i32 0
+  store i253 %15, ptr %field_0_ptr6, align 4
+  %return_struct_value7 = load { i253 }, ptr %ret_struct_ptr5, align 4
+  ret { i253 } %return_struct_value7
 }
 
-define { {} } @"fib_caller::fib_caller::fib_mid"(i252 %0) {
+define { {} } @"fib_bench::fib_bench::fib_mid"(i253 %0) {
 entry:
-  %1 = call { i252, i252 } @"dup<felt>"(i252 %0)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %1, ptr %res_ptr, align 4
-  %"0_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"0" = load i252, ptr %"0_ptr", align 4
-  %"2_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"2" = load i252, ptr %"2_ptr", align 4
-  %check = icmp eq i252 %"2", 0
+  %1 = call { i253, i253 } @"dup<felt>"(i253 %0)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %1, ptr %res_ptr, align 4
+  %"0_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"0" = load i253, ptr %"0_ptr", align 4
+  %"2_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"2" = load i253, ptr %"2_ptr", align 4
+  %check = icmp eq i253 %"2", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -306,21 +304,21 @@ dest:                                             ; preds = %then
   ret { {} } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %4 = call i252 @"felt_const<0>"()
-  %5 = call i252 @"felt_const<1>"()
-  %6 = call i252 @"felt_const<500>"()
-  %7 = call i252 @"store_temp<felt>"(i252 %4)
-  %8 = call i252 @"store_temp<felt>"(i252 %5)
-  %9 = call i252 @"store_temp<felt>"(i252 %6)
-  %10 = call { i252 } @"fib_caller::fib_caller::fib"(i252 %7, i252 %8, i252 %9)
-  %res_ptr2 = alloca { i252 }, align 8
-  store { i252 } %10, ptr %res_ptr2, align 4
-  %"6_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"6" = load i252, ptr %"6_ptr", align 4
-  %11 = call i252 @"felt_const<1>"()
-  %12 = call i252 @felt_sub(i252 %"0", i252 %11)
-  %13 = call i252 @"store_temp<felt>"(i252 %12)
-  %14 = call { {} } @"fib_caller::fib_caller::fib_mid"(i252 %13)
+  %4 = call i253 @"felt_const<0>"()
+  %5 = call i253 @"felt_const<1>"()
+  %6 = call i253 @"felt_const<500>"()
+  %7 = call i253 @"store_temp<felt>"(i253 %4)
+  %8 = call i253 @"store_temp<felt>"(i253 %5)
+  %9 = call i253 @"store_temp<felt>"(i253 %6)
+  %10 = call { i253 } @"fib_bench::fib_bench::fib"(i253 %7, i253 %8, i253 %9)
+  %res_ptr2 = alloca { i253 }, align 8
+  store { i253 } %10, ptr %res_ptr2, align 4
+  %"6_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"6" = load i253, ptr %"6_ptr", align 4
+  %11 = call i253 @"felt_const<1>"()
+  %12 = call i253 @felt_sub(i253 %"0", i253 %11)
+  %13 = call i253 @"store_temp<felt>"(i253 %12)
+  %14 = call { {} } @"fib_bench::fib_bench::fib_mid"(i253 %13)
   %res_ptr3 = alloca { {} }, align 8
   store { {} } %14, ptr %res_ptr3, align 1
   %"12_ptr" = getelementptr inbounds { {} }, ptr %res_ptr3, i32 0, i32 0
@@ -334,11 +332,11 @@ dest1:                                            ; preds = %else
   ret { {} } %return_struct_value6
 }
 
-define i32 @main(i252 %0) {
+define i32 @main(i253 %0) {
 entry:
-  %1 = call i252 @"felt_const<100>"()
-  %2 = call i252 @"store_temp<felt>"(i252 %1)
-  %3 = call { {} } @"fib_caller::fib_caller::fib_mid"(i252 %2)
+  %1 = call i253 @"felt_const<100>"()
+  %2 = call i253 @"store_temp<felt>"(i253 %1)
+  %3 = call { {} } @"fib_bench::fib_bench::fib_mid"(i253 %2)
   %res_ptr = alloca { {} }, align 8
   store { {} } %3, ptr %res_ptr, align 1
   %"2_ptr" = getelementptr inbounds { {} }, ptr %res_ptr, i32 0, i32 0

--- a/core/tests/test_data/llvm/fib_box.ll
+++ b/core/tests/test_data/llvm/fib_box.ll
@@ -2,287 +2,285 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define i252 @"unbox<felt>"(i252 %0) {
+define i253 @modulo(i512 %0) {
 entry:
-  ret i252 %0
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define i253 @"unbox<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  ret i253 %0
 }
 
-define { i252, i252 } @"dup<felt>"(i252 %0) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  ret i253 %0
 }
 
-define i252 @"store_temp<Box<felt>>"(i252 %0) {
+define { i253, i253 } @"dup<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define { i252, i252 } @"dup<Box<felt>>"(i252 %0) {
+define i253 @"store_temp<Box<felt>>"(i253 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  ret i253 %0
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define { i253, i253 } @"dup<Box<felt>>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define i252 @"into_box<felt>"(i252 %0) {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @"into_box<felt>"(i253 %0) {
 entry:
-  ret i252 1
+  ret i253 %0
 }
 
-define i252 @felt_sub(i252 %0, i252 %1) {
+define i253 @"felt_const<1>"() {
 entry:
-  %res = sub i252 %0, %1
-  %arg = sext i252 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 1
 }
 
-define i252 @"rename<Box<felt>>"(i252 %0) {
+define i253 @felt_sub(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %res = sub i253 %0, %1
+  %arg = sext i253 %res to i512
+  %res1 = call i253 @modulo(i512 %arg)
+  ret i253 %res1
 }
 
-define { i252 } @"fib_box::fib_box::fib"(i252 %0, i252 %1, i252 %2) {
+define i253 @"rename<Box<felt>>"(i253 %0) {
 entry:
-  %3 = call i252 @"unbox<felt>"(i252 %2)
-  %4 = call i252 @"store_temp<felt>"(i252 %3)
-  %5 = call { i252, i252 } @"dup<felt>"(i252 %4)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %5, ptr %res_ptr, align 4
-  %"3_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"3" = load i252, ptr %"3_ptr", align 4
-  %"5_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"5" = load i252, ptr %"5_ptr", align 4
-  %check = icmp eq i252 %"5", 0
+  ret i253 %0
+}
+
+define { i253 } @"fib_box::fib_box::fib"(i253 %0, i253 %1, i253 %2) {
+entry:
+  %3 = call i253 @"unbox<felt>"(i253 %2)
+  %4 = call i253 @"store_temp<felt>"(i253 %3)
+  %5 = call { i253, i253 } @"dup<felt>"(i253 %4)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %5, ptr %res_ptr, align 4
+  %"3_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"3" = load i253, ptr %"3_ptr", align 4
+  %"5_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"5" = load i253, ptr %"5_ptr", align 4
+  %check = icmp eq i253 %"5", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = call i252 @"store_temp<Box<felt>>"(i252 %0)
+  %6 = call i253 @"store_temp<Box<felt>>"(i253 %0)
   br label %dest
 
 else:                                             ; preds = %entry
   br label %dest1
 
 dest:                                             ; preds = %then
-  %7 = call i252 @"rename<Box<felt>>"(i252 %6)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %7, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  ret { i252 } %return_struct_value
+  %7 = call i253 @"rename<Box<felt>>"(i253 %6)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %7, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  ret { i253 } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %8 = call i252 @"unbox<felt>"(i252 %0)
-  %9 = call { i252, i252 } @"dup<Box<felt>>"(i252 %1)
-  %res_ptr2 = alloca { i252, i252 }, align 8
-  store { i252, i252 } %9, ptr %res_ptr2, align 4
-  %"1_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"1" = load i252, ptr %"1_ptr", align 4
-  %"9_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 1
-  %"9" = load i252, ptr %"9_ptr", align 4
-  %10 = call i252 @"unbox<felt>"(i252 %"9")
-  %11 = call i252 @"store_temp<felt>"(i252 %8)
-  %12 = call i252 @"store_temp<felt>"(i252 %10)
-  %13 = call i252 @felt_add(i252 %11, i252 %12)
-  %14 = call i252 @"store_temp<felt>"(i252 %13)
-  %15 = call i252 @"into_box<felt>"(i252 %14)
-  %16 = call i252 @"felt_const<1>"()
-  %17 = call i252 @felt_sub(i252 %"3", i252 %16)
-  %18 = call i252 @"store_temp<felt>"(i252 %17)
-  %19 = call i252 @"into_box<felt>"(i252 %18)
-  %20 = call i252 @"store_temp<Box<felt>>"(i252 %"1")
-  %21 = call i252 @"store_temp<Box<felt>>"(i252 %15)
-  %22 = call i252 @"store_temp<Box<felt>>"(i252 %19)
-  %23 = call { i252 } @"fib_box::fib_box::fib"(i252 %20, i252 %21, i252 %22)
-  %res_ptr3 = alloca { i252 }, align 8
-  store { i252 } %23, ptr %res_ptr3, align 4
-  %"15_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr3, i32 0, i32 0
-  %"15" = load i252, ptr %"15_ptr", align 4
-  %24 = call i252 @"rename<Box<felt>>"(i252 %"15")
+  %8 = call i253 @"unbox<felt>"(i253 %0)
+  %9 = call { i253, i253 } @"dup<Box<felt>>"(i253 %1)
+  %res_ptr2 = alloca { i253, i253 }, align 8
+  store { i253, i253 } %9, ptr %res_ptr2, align 4
+  %"1_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"1" = load i253, ptr %"1_ptr", align 4
+  %"9_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 1
+  %"9" = load i253, ptr %"9_ptr", align 4
+  %10 = call i253 @"unbox<felt>"(i253 %"9")
+  %11 = call i253 @"store_temp<felt>"(i253 %8)
+  %12 = call i253 @"store_temp<felt>"(i253 %10)
+  %13 = call i253 @felt_add(i253 %11, i253 %12)
+  %14 = call i253 @"store_temp<felt>"(i253 %13)
+  %15 = call i253 @"into_box<felt>"(i253 %14)
+  %16 = call i253 @"felt_const<1>"()
+  %17 = call i253 @felt_sub(i253 %"3", i253 %16)
+  %18 = call i253 @"store_temp<felt>"(i253 %17)
+  %19 = call i253 @"into_box<felt>"(i253 %18)
+  %20 = call i253 @"store_temp<Box<felt>>"(i253 %"1")
+  %21 = call i253 @"store_temp<Box<felt>>"(i253 %15)
+  %22 = call i253 @"store_temp<Box<felt>>"(i253 %19)
+  %23 = call { i253 } @"fib_box::fib_box::fib"(i253 %20, i253 %21, i253 %22)
+  %res_ptr3 = alloca { i253 }, align 8
+  store { i253 } %23, ptr %res_ptr3, align 4
+  %"15_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr3, i32 0, i32 0
+  %"15" = load i253, ptr %"15_ptr", align 4
+  %24 = call i253 @"rename<Box<felt>>"(i253 %"15")
   br label %dest4
 
 dest4:                                            ; preds = %dest1
-  %25 = call i252 @"rename<Box<felt>>"(i252 %24)
-  %ret_struct_ptr5 = alloca { i252 }, align 8
-  %field_0_ptr6 = getelementptr inbounds { i252 }, ptr %ret_struct_ptr5, i32 0, i32 0
-  store i252 %25, ptr %field_0_ptr6, align 4
-  %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
-  ret { i252 } %return_struct_value7
+  %25 = call i253 @"rename<Box<felt>>"(i253 %24)
+  %ret_struct_ptr5 = alloca { i253 }, align 8
+  %field_0_ptr6 = getelementptr inbounds { i253 }, ptr %ret_struct_ptr5, i32 0, i32 0
+  store i253 %25, ptr %field_0_ptr6, align 4
+  %return_struct_value7 = load { i253 }, ptr %ret_struct_ptr5, align 4
+  ret { i253 } %return_struct_value7
 }

--- a/core/tests/test_data/llvm/fib_box_main.ll
+++ b/core/tests/test_data/llvm/fib_box_main.ll
@@ -2,345 +2,343 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define i252 @"unbox<felt>"(i252 %0) {
+define i253 @modulo(i512 %0) {
 entry:
-  ret i252 %0
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define i253 @"unbox<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  ret i253 %0
 }
 
-define { i252, i252 } @"dup<felt>"(i252 %0) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  ret i253 %0
 }
 
-define i252 @"store_temp<Box<felt>>"(i252 %0) {
+define { i253, i253 } @"dup<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define { i252, i252 } @"dup<Box<felt>>"(i252 %0) {
+define i253 @"store_temp<Box<felt>>"(i253 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  ret i253 %0
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define { i253, i253 } @"dup<Box<felt>>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define i252 @"into_box<felt>"(i252 %0) {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @"into_box<felt>"(i253 %0) {
 entry:
-  ret i252 1
+  ret i253 %0
 }
 
-define i252 @felt_sub(i252 %0, i252 %1) {
+define i253 @"felt_const<1>"() {
 entry:
-  %res = sub i252 %0, %1
-  %arg = sext i252 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 1
 }
 
-define i252 @"rename<Box<felt>>"(i252 %0) {
+define i253 @felt_sub(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %res = sub i253 %0, %1
+  %arg = sext i253 %res to i512
+  %res1 = call i253 @modulo(i512 %arg)
+  ret i253 %res1
 }
 
-define i252 @"felt_const<0>"() {
+define i253 @"rename<Box<felt>>"(i253 %0) {
 entry:
-  ret i252 0
+  ret i253 %0
 }
 
-define i252 @"felt_const<30>"() {
+define i253 @"felt_const<0>"() {
 entry:
-  ret i252 30
+  ret i253 0
 }
 
-define { i252 } @"fib_box::fib_box::fib"(i252 %0, i252 %1, i252 %2) {
+define i253 @"felt_const<30>"() {
 entry:
-  %3 = call i252 @"unbox<felt>"(i252 %2)
-  %4 = call i252 @"store_temp<felt>"(i252 %3)
-  %5 = call { i252, i252 } @"dup<felt>"(i252 %4)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %5, ptr %res_ptr, align 4
-  %"3_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"3" = load i252, ptr %"3_ptr", align 4
-  %"5_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"5" = load i252, ptr %"5_ptr", align 4
-  %check = icmp eq i252 %"5", 0
+  ret i253 30
+}
+
+define { i253 } @"fib_box::fib_box::fib"(i253 %0, i253 %1, i253 %2) {
+entry:
+  %3 = call i253 @"unbox<felt>"(i253 %2)
+  %4 = call i253 @"store_temp<felt>"(i253 %3)
+  %5 = call { i253, i253 } @"dup<felt>"(i253 %4)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %5, ptr %res_ptr, align 4
+  %"3_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"3" = load i253, ptr %"3_ptr", align 4
+  %"5_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"5" = load i253, ptr %"5_ptr", align 4
+  %check = icmp eq i253 %"5", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = call i252 @"store_temp<Box<felt>>"(i252 %0)
+  %6 = call i253 @"store_temp<Box<felt>>"(i253 %0)
   br label %dest
 
 else:                                             ; preds = %entry
   br label %dest1
 
 dest:                                             ; preds = %then
-  %7 = call i252 @"rename<Box<felt>>"(i252 %6)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %7, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  ret { i252 } %return_struct_value
+  %7 = call i253 @"rename<Box<felt>>"(i253 %6)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %7, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  ret { i253 } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %8 = call i252 @"unbox<felt>"(i252 %0)
-  %9 = call { i252, i252 } @"dup<Box<felt>>"(i252 %1)
-  %res_ptr2 = alloca { i252, i252 }, align 8
-  store { i252, i252 } %9, ptr %res_ptr2, align 4
-  %"1_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"1" = load i252, ptr %"1_ptr", align 4
-  %"9_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 1
-  %"9" = load i252, ptr %"9_ptr", align 4
-  %10 = call i252 @"unbox<felt>"(i252 %"9")
-  %11 = call i252 @"store_temp<felt>"(i252 %8)
-  %12 = call i252 @"store_temp<felt>"(i252 %10)
-  %13 = call i252 @felt_add(i252 %11, i252 %12)
-  %14 = call i252 @"store_temp<felt>"(i252 %13)
-  %15 = call i252 @"into_box<felt>"(i252 %14)
-  %16 = call i252 @"felt_const<1>"()
-  %17 = call i252 @felt_sub(i252 %"3", i252 %16)
-  %18 = call i252 @"store_temp<felt>"(i252 %17)
-  %19 = call i252 @"into_box<felt>"(i252 %18)
-  %20 = call i252 @"store_temp<Box<felt>>"(i252 %"1")
-  %21 = call i252 @"store_temp<Box<felt>>"(i252 %15)
-  %22 = call i252 @"store_temp<Box<felt>>"(i252 %19)
-  %23 = call { i252 } @"fib_box::fib_box::fib"(i252 %20, i252 %21, i252 %22)
-  %res_ptr3 = alloca { i252 }, align 8
-  store { i252 } %23, ptr %res_ptr3, align 4
-  %"15_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr3, i32 0, i32 0
-  %"15" = load i252, ptr %"15_ptr", align 4
-  %24 = call i252 @"rename<Box<felt>>"(i252 %"15")
+  %8 = call i253 @"unbox<felt>"(i253 %0)
+  %9 = call { i253, i253 } @"dup<Box<felt>>"(i253 %1)
+  %res_ptr2 = alloca { i253, i253 }, align 8
+  store { i253, i253 } %9, ptr %res_ptr2, align 4
+  %"1_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"1" = load i253, ptr %"1_ptr", align 4
+  %"9_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 1
+  %"9" = load i253, ptr %"9_ptr", align 4
+  %10 = call i253 @"unbox<felt>"(i253 %"9")
+  %11 = call i253 @"store_temp<felt>"(i253 %8)
+  %12 = call i253 @"store_temp<felt>"(i253 %10)
+  %13 = call i253 @felt_add(i253 %11, i253 %12)
+  %14 = call i253 @"store_temp<felt>"(i253 %13)
+  %15 = call i253 @"into_box<felt>"(i253 %14)
+  %16 = call i253 @"felt_const<1>"()
+  %17 = call i253 @felt_sub(i253 %"3", i253 %16)
+  %18 = call i253 @"store_temp<felt>"(i253 %17)
+  %19 = call i253 @"into_box<felt>"(i253 %18)
+  %20 = call i253 @"store_temp<Box<felt>>"(i253 %"1")
+  %21 = call i253 @"store_temp<Box<felt>>"(i253 %15)
+  %22 = call i253 @"store_temp<Box<felt>>"(i253 %19)
+  %23 = call { i253 } @"fib_box::fib_box::fib"(i253 %20, i253 %21, i253 %22)
+  %res_ptr3 = alloca { i253 }, align 8
+  store { i253 } %23, ptr %res_ptr3, align 4
+  %"15_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr3, i32 0, i32 0
+  %"15" = load i253, ptr %"15_ptr", align 4
+  %24 = call i253 @"rename<Box<felt>>"(i253 %"15")
   br label %dest4
 
 dest4:                                            ; preds = %dest1
-  %25 = call i252 @"rename<Box<felt>>"(i252 %24)
-  %ret_struct_ptr5 = alloca { i252 }, align 8
-  %field_0_ptr6 = getelementptr inbounds { i252 }, ptr %ret_struct_ptr5, i32 0, i32 0
-  store i252 %25, ptr %field_0_ptr6, align 4
-  %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
-  ret { i252 } %return_struct_value7
+  %25 = call i253 @"rename<Box<felt>>"(i253 %24)
+  %ret_struct_ptr5 = alloca { i253 }, align 8
+  %field_0_ptr6 = getelementptr inbounds { i253 }, ptr %ret_struct_ptr5, i32 0, i32 0
+  store i253 %25, ptr %field_0_ptr6, align 4
+  %return_struct_value7 = load { i253 }, ptr %ret_struct_ptr5, align 4
+  ret { i253 } %return_struct_value7
 }
 
-define void @print_return(i252 %0) {
+define void @print_return(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
@@ -348,34 +346,34 @@ entry:
 
 define i32 @main() {
 entry:
-  %0 = call i252 @"felt_const<0>"()
-  %1 = call i252 @"store_temp<felt>"(i252 %0)
-  %2 = call i252 @"into_box<felt>"(i252 %1)
-  %3 = call i252 @"felt_const<1>"()
-  %4 = call i252 @"store_temp<felt>"(i252 %3)
-  %5 = call i252 @"into_box<felt>"(i252 %4)
-  %6 = call i252 @"felt_const<30>"()
-  %7 = call i252 @"store_temp<felt>"(i252 %6)
-  %8 = call i252 @"into_box<felt>"(i252 %7)
-  %9 = call i252 @"store_temp<Box<felt>>"(i252 %2)
-  %10 = call i252 @"store_temp<Box<felt>>"(i252 %5)
-  %11 = call i252 @"store_temp<Box<felt>>"(i252 %8)
-  %12 = call { i252 } @"fib_box::fib_box::fib"(i252 %9, i252 %10, i252 %11)
-  %res_ptr = alloca { i252 }, align 8
-  store { i252 } %12, ptr %res_ptr, align 4
-  %"6_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr, i32 0, i32 0
-  %"6" = load i252, ptr %"6_ptr", align 4
-  %13 = call i252 @"unbox<felt>"(i252 %"6")
-  %14 = call i252 @"store_temp<felt>"(i252 %13)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %14, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  %return_value = load i252, ptr %return_value_ptr, align 4
-  %format = alloca [14 x i8], align 1
+  %0 = call i253 @"felt_const<0>"()
+  %1 = call i253 @"store_temp<felt>"(i253 %0)
+  %2 = call i253 @"into_box<felt>"(i253 %1)
+  %3 = call i253 @"felt_const<1>"()
+  %4 = call i253 @"store_temp<felt>"(i253 %3)
+  %5 = call i253 @"into_box<felt>"(i253 %4)
+  %6 = call i253 @"felt_const<30>"()
+  %7 = call i253 @"store_temp<felt>"(i253 %6)
+  %8 = call i253 @"into_box<felt>"(i253 %7)
+  %9 = call i253 @"store_temp<Box<felt>>"(i253 %2)
+  %10 = call i253 @"store_temp<Box<felt>>"(i253 %5)
+  %11 = call i253 @"store_temp<Box<felt>>"(i253 %8)
+  %12 = call { i253 } @"fib_box::fib_box::fib"(i253 %9, i253 %10, i253 %11)
+  %res_ptr = alloca { i253 }, align 8
+  store { i253 } %12, ptr %res_ptr, align 4
+  %"6_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr, i32 0, i32 0
+  %"6" = load i253, ptr %"6_ptr", align 4
+  %13 = call i253 @"unbox<felt>"(i253 %"6")
+  %14 = call i253 @"store_temp<felt>"(i253 %13)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %14, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  %return_value_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i253, ptr %return_value_ptr, align 4
+  %format = alloca [15 x i8], align 1
   store [15 x i8] c"Return value: \00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format)
-  call void @print_return(i252 %return_value)
+  call void @print_return(i253 %return_value)
   ret i32 0
 }

--- a/core/tests/test_data/llvm/fib_main.ll
+++ b/core/tests/test_data/llvm/fib_main.ll
@@ -2,337 +2,335 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define { i252, i252 } @"dup<felt>"(i252 %0) {
+define i253 @modulo(i512 %0) {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %tuple_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %tuple_ptr, align 4
-  %tuple_ptr_2 = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %0, ptr %tuple_ptr_2, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"store_temp<felt>"(i252 %0) {
+define { i253, i253 } @"dup<felt>"(i253 %0) {
 entry:
-  ret i252 %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %tuple_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %tuple_ptr, align 4
+  %tuple_ptr_2 = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %0, ptr %tuple_ptr_2, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define i252 @felt_add(i252 %0, i252 %1) {
+define i253 @"store_temp<felt>"(i253 %0) {
 entry:
-  %extended_a = sext i252 %0 to i253
-  %extended_b = sext i252 %1 to i253
-  %res = add i253 %extended_a, %extended_b
-  %arg = sext i253 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 %0
 }
 
-define i252 @"felt_const<1>"() {
+define i253 @felt_add(i253 %0, i253 %1) {
 entry:
-  ret i252 1
+  %extended_a = sext i253 %0 to i512
+  %extended_b = sext i253 %1 to i512
+  %res = add i512 %extended_a, %extended_b
+  %res1 = call i253 @modulo(i512 %res)
+  ret i253 %res1
 }
 
-define i252 @felt_sub(i252 %0, i252 %1) {
+define i253 @"felt_const<1>"() {
 entry:
-  %res = sub i252 %0, %1
-  %arg = sext i252 %res to i503
-  %res1 = call i252 @modulo(i503 %arg)
-  ret i252 %res1
+  ret i253 1
 }
 
-define i252 @"rename<felt>"(i252 %0) {
+define i253 @felt_sub(i253 %0, i253 %1) {
 entry:
-  ret i252 %0
+  %res = sub i253 %0, %1
+  %arg = sext i253 %res to i512
+  %res1 = call i253 @modulo(i512 %arg)
+  ret i253 %res1
 }
 
-define i252 @"felt_const<0>"() {
+define i253 @"rename<felt>"(i253 %0) {
 entry:
-  ret i252 0
+  ret i253 %0
 }
 
-define i252 @"felt_const<30>"() {
+define i253 @"felt_const<0>"() {
 entry:
-  ret i252 30
+  ret i253 0
 }
 
-define { i252 } @"fib_caller::fib_caller::fib"(i252 %0, i252 %1, i252 %2) {
+define i253 @"felt_const<30>"() {
 entry:
-  %3 = call { i252, i252 } @"dup<felt>"(i252 %2)
-  %res_ptr = alloca { i252, i252 }, align 8
-  store { i252, i252 } %3, ptr %res_ptr, align 4
-  %"2_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  %"2" = load i252, ptr %"2_ptr", align 4
-  %"4_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  %"4" = load i252, ptr %"4_ptr", align 4
-  %check = icmp eq i252 %"4", 0
+  ret i253 30
+}
+
+define { i253 } @"fib_caller::fib_caller::fib"(i253 %0, i253 %1, i253 %2) {
+entry:
+  %3 = call { i253, i253 } @"dup<felt>"(i253 %2)
+  %res_ptr = alloca { i253, i253 }, align 8
+  store { i253, i253 } %3, ptr %res_ptr, align 4
+  %"2_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  %"2" = load i253, ptr %"2_ptr", align 4
+  %"4_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  %"4" = load i253, ptr %"4_ptr", align 4
+  %check = icmp eq i253 %"4", 0
   br i1 %check, label %then, label %else
 
 then:                                             ; preds = %entry
-  %4 = call i252 @"store_temp<felt>"(i252 %0)
+  %4 = call i253 @"store_temp<felt>"(i253 %0)
   br label %dest
 
 else:                                             ; preds = %entry
   br label %dest1
 
 dest:                                             ; preds = %then
-  %5 = call i252 @"rename<felt>"(i252 %4)
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %5, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  ret { i252 } %return_struct_value
+  %5 = call i253 @"rename<felt>"(i253 %4)
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %5, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  ret { i253 } %return_struct_value
 
 dest1:                                            ; preds = %else
-  %6 = call { i252, i252 } @"dup<felt>"(i252 %1)
-  %res_ptr2 = alloca { i252, i252 }, align 8
-  store { i252, i252 } %6, ptr %res_ptr2, align 4
-  %"1_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 0
-  %"1" = load i252, ptr %"1_ptr", align 4
-  %"7_ptr" = getelementptr inbounds { i252, i252 }, ptr %res_ptr2, i32 0, i32 1
-  %"7" = load i252, ptr %"7_ptr", align 4
-  %7 = call i252 @felt_add(i252 %0, i252 %"7")
-  %8 = call i252 @"felt_const<1>"()
-  %9 = call i252 @felt_sub(i252 %"2", i252 %8)
-  %10 = call i252 @"store_temp<felt>"(i252 %"1")
-  %11 = call i252 @"store_temp<felt>"(i252 %7)
-  %12 = call i252 @"store_temp<felt>"(i252 %9)
-  %13 = call { i252 } @"fib_caller::fib_caller::fib"(i252 %10, i252 %11, i252 %12)
-  %res_ptr3 = alloca { i252 }, align 8
-  store { i252 } %13, ptr %res_ptr3, align 4
-  %"10_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr3, i32 0, i32 0
-  %"10" = load i252, ptr %"10_ptr", align 4
-  %14 = call i252 @"rename<felt>"(i252 %"10")
+  %6 = call { i253, i253 } @"dup<felt>"(i253 %1)
+  %res_ptr2 = alloca { i253, i253 }, align 8
+  store { i253, i253 } %6, ptr %res_ptr2, align 4
+  %"1_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 0
+  %"1" = load i253, ptr %"1_ptr", align 4
+  %"7_ptr" = getelementptr inbounds { i253, i253 }, ptr %res_ptr2, i32 0, i32 1
+  %"7" = load i253, ptr %"7_ptr", align 4
+  %7 = call i253 @felt_add(i253 %0, i253 %"7")
+  %8 = call i253 @"felt_const<1>"()
+  %9 = call i253 @felt_sub(i253 %"2", i253 %8)
+  %10 = call i253 @"store_temp<felt>"(i253 %"1")
+  %11 = call i253 @"store_temp<felt>"(i253 %7)
+  %12 = call i253 @"store_temp<felt>"(i253 %9)
+  %13 = call { i253 } @"fib_caller::fib_caller::fib"(i253 %10, i253 %11, i253 %12)
+  %res_ptr3 = alloca { i253 }, align 8
+  store { i253 } %13, ptr %res_ptr3, align 4
+  %"10_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr3, i32 0, i32 0
+  %"10" = load i253, ptr %"10_ptr", align 4
+  %14 = call i253 @"rename<felt>"(i253 %"10")
   br label %dest4
 
 dest4:                                            ; preds = %dest1
-  %15 = call i252 @"rename<felt>"(i252 %14)
-  %ret_struct_ptr5 = alloca { i252 }, align 8
-  %field_0_ptr6 = getelementptr inbounds { i252 }, ptr %ret_struct_ptr5, i32 0, i32 0
-  store i252 %15, ptr %field_0_ptr6, align 4
-  %return_struct_value7 = load { i252 }, ptr %ret_struct_ptr5, align 4
-  ret { i252 } %return_struct_value7
+  %15 = call i253 @"rename<felt>"(i253 %14)
+  %ret_struct_ptr5 = alloca { i253 }, align 8
+  %field_0_ptr6 = getelementptr inbounds { i253 }, ptr %ret_struct_ptr5, i32 0, i32 0
+  store i253 %15, ptr %field_0_ptr6, align 4
+  %return_struct_value7 = load { i253 }, ptr %ret_struct_ptr5, align 4
+  ret { i253 } %return_struct_value7
 }
 
-define void @print_return(i252 %0) {
+define void @print_return(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define i32 @main(i252 %0) {
+define i32 @main(i253 %0) {
 entry:
-  %1 = call i252 @"felt_const<0>"()
-  %2 = call i252 @"felt_const<1>"()
-  %3 = call i252 @"felt_const<30>"()
-  %4 = call i252 @"store_temp<felt>"(i252 %1)
-  %5 = call i252 @"store_temp<felt>"(i252 %2)
-  %6 = call i252 @"store_temp<felt>"(i252 %3)
-  %7 = call { i252 } @"fib_caller::fib_caller::fib"(i252 %4, i252 %5, i252 %6)
-  %res_ptr = alloca { i252 }, align 8
-  store { i252 } %7, ptr %res_ptr, align 4
-  %"4_ptr" = getelementptr inbounds { i252 }, ptr %res_ptr, i32 0, i32 0
-  %"4" = load i252, ptr %"4_ptr", align 4
-  %8 = call i252 @"rename<felt>"(i252 %"4")
-  %ret_struct_ptr = alloca { i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  store i252 %8, ptr %field_0_ptr, align 4
-  %return_struct_value = load { i252 }, ptr %ret_struct_ptr, align 4
-  %return_value_ptr = getelementptr inbounds { i252 }, ptr %ret_struct_ptr, i32 0, i32 0
-  %return_value = load i252, ptr %return_value_ptr, align 4
-  %format = alloca [14 x i8], align 1
+  %1 = call i253 @"felt_const<0>"()
+  %2 = call i253 @"felt_const<1>"()
+  %3 = call i253 @"felt_const<30>"()
+  %4 = call i253 @"store_temp<felt>"(i253 %1)
+  %5 = call i253 @"store_temp<felt>"(i253 %2)
+  %6 = call i253 @"store_temp<felt>"(i253 %3)
+  %7 = call { i253 } @"fib_caller::fib_caller::fib"(i253 %4, i253 %5, i253 %6)
+  %res_ptr = alloca { i253 }, align 8
+  store { i253 } %7, ptr %res_ptr, align 4
+  %"4_ptr" = getelementptr inbounds { i253 }, ptr %res_ptr, i32 0, i32 0
+  %"4" = load i253, ptr %"4_ptr", align 4
+  %8 = call i253 @"rename<felt>"(i253 %"4")
+  %ret_struct_ptr = alloca { i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  store i253 %8, ptr %field_0_ptr, align 4
+  %return_struct_value = load { i253 }, ptr %ret_struct_ptr, align 4
+  %return_value_ptr = getelementptr inbounds { i253 }, ptr %ret_struct_ptr, i32 0, i32 0
+  %return_value = load i253, ptr %return_value_ptr, align 4
+  %format = alloca [15 x i8], align 1
   store [15 x i8] c"Return value: \00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format)
-  call void @print_return(i252 %return_value)
+  call void @print_return(i253 %return_value)
   ret i32 0
 }

--- a/core/tests/test_data/llvm/struct_construct.ll
+++ b/core/tests/test_data/llvm/struct_construct.ll
@@ -2,188 +2,187 @@
 source_filename = "root"
 target triple = "x86_64-pc-linux-gnu"
 
-define i252 @modulo(i503 %0) {
-entry:
-  %modulus = srem i503 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
-  %res = trunc i503 %modulus to i252
-  ret i252 %res
-}
-
 declare i32 @printf(ptr, ...)
 
-define void @print_felt(i252 %0) {
+define void @print_felt(i253 %0) {
 entry:
-  %rounded_size_val = sext i252 %0 to i256
+  %rounded_size_val = sext i253 %0 to i256
   %shifted = lshr i256 %rounded_size_val, 224
   %print_value_trunc = trunc i256 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
   %shifted1 = lshr i256 %rounded_size_val, 192
   %print_value_trunc2 = trunc i256 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
   %shifted5 = lshr i256 %rounded_size_val, 160
   %print_value_trunc6 = trunc i256 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
   %shifted9 = lshr i256 %rounded_size_val, 128
   %print_value_trunc10 = trunc i256 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
   %shifted13 = lshr i256 %rounded_size_val, 96
   %print_value_trunc14 = trunc i256 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
   %shifted17 = lshr i256 %rounded_size_val, 64
   %print_value_trunc18 = trunc i256 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
   %shifted21 = lshr i256 %rounded_size_val, 32
   %print_value_trunc22 = trunc i256 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
   %shifted25 = lshr i256 %rounded_size_val, 0
   %print_value_trunc26 = trunc i256 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %format29 = alloca [1 x i8], align 1
+  %format29 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format29, align 1
   %chars_printed30 = call i32 (ptr, ...) @printf(ptr %format29)
   ret void
 }
 
-define void @print_double_felt(i503 %0) {
+define void @print_double_felt(i512 %0) {
 entry:
-  %rounded_size_val = sext i503 %0 to i512
-  %shifted = lshr i512 %rounded_size_val, 480
+  %shifted = lshr i512 %0, 480
   %print_value_trunc = trunc i512 %shifted to i32
-  %format = alloca [4 x i8], align 1
+  %format = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format, align 1
   %chars_printed = call i32 (ptr, ...) @printf(ptr %format, i32 %print_value_trunc)
-  %shifted1 = lshr i512 %rounded_size_val, 448
+  %shifted1 = lshr i512 %0, 448
   %print_value_trunc2 = trunc i512 %shifted1 to i32
-  %format3 = alloca [4 x i8], align 1
+  %format3 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format3, align 1
   %chars_printed4 = call i32 (ptr, ...) @printf(ptr %format3, i32 %print_value_trunc2)
-  %shifted5 = lshr i512 %rounded_size_val, 416
+  %shifted5 = lshr i512 %0, 416
   %print_value_trunc6 = trunc i512 %shifted5 to i32
-  %format7 = alloca [4 x i8], align 1
+  %format7 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format7, align 1
   %chars_printed8 = call i32 (ptr, ...) @printf(ptr %format7, i32 %print_value_trunc6)
-  %shifted9 = lshr i512 %rounded_size_val, 384
+  %shifted9 = lshr i512 %0, 384
   %print_value_trunc10 = trunc i512 %shifted9 to i32
-  %format11 = alloca [4 x i8], align 1
+  %format11 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format11, align 1
   %chars_printed12 = call i32 (ptr, ...) @printf(ptr %format11, i32 %print_value_trunc10)
-  %shifted13 = lshr i512 %rounded_size_val, 352
+  %shifted13 = lshr i512 %0, 352
   %print_value_trunc14 = trunc i512 %shifted13 to i32
-  %format15 = alloca [4 x i8], align 1
+  %format15 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format15, align 1
   %chars_printed16 = call i32 (ptr, ...) @printf(ptr %format15, i32 %print_value_trunc14)
-  %shifted17 = lshr i512 %rounded_size_val, 320
+  %shifted17 = lshr i512 %0, 320
   %print_value_trunc18 = trunc i512 %shifted17 to i32
-  %format19 = alloca [4 x i8], align 1
+  %format19 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format19, align 1
   %chars_printed20 = call i32 (ptr, ...) @printf(ptr %format19, i32 %print_value_trunc18)
-  %shifted21 = lshr i512 %rounded_size_val, 288
+  %shifted21 = lshr i512 %0, 288
   %print_value_trunc22 = trunc i512 %shifted21 to i32
-  %format23 = alloca [4 x i8], align 1
+  %format23 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format23, align 1
   %chars_printed24 = call i32 (ptr, ...) @printf(ptr %format23, i32 %print_value_trunc22)
-  %shifted25 = lshr i512 %rounded_size_val, 256
+  %shifted25 = lshr i512 %0, 256
   %print_value_trunc26 = trunc i512 %shifted25 to i32
-  %format27 = alloca [4 x i8], align 1
+  %format27 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format27, align 1
   %chars_printed28 = call i32 (ptr, ...) @printf(ptr %format27, i32 %print_value_trunc26)
-  %shifted29 = lshr i512 %rounded_size_val, 224
+  %shifted29 = lshr i512 %0, 224
   %print_value_trunc30 = trunc i512 %shifted29 to i32
-  %format31 = alloca [4 x i8], align 1
+  %format31 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format31, align 1
   %chars_printed32 = call i32 (ptr, ...) @printf(ptr %format31, i32 %print_value_trunc30)
-  %shifted33 = lshr i512 %rounded_size_val, 192
+  %shifted33 = lshr i512 %0, 192
   %print_value_trunc34 = trunc i512 %shifted33 to i32
-  %format35 = alloca [4 x i8], align 1
+  %format35 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format35, align 1
   %chars_printed36 = call i32 (ptr, ...) @printf(ptr %format35, i32 %print_value_trunc34)
-  %shifted37 = lshr i512 %rounded_size_val, 160
+  %shifted37 = lshr i512 %0, 160
   %print_value_trunc38 = trunc i512 %shifted37 to i32
-  %format39 = alloca [4 x i8], align 1
+  %format39 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format39, align 1
   %chars_printed40 = call i32 (ptr, ...) @printf(ptr %format39, i32 %print_value_trunc38)
-  %shifted41 = lshr i512 %rounded_size_val, 128
+  %shifted41 = lshr i512 %0, 128
   %print_value_trunc42 = trunc i512 %shifted41 to i32
-  %format43 = alloca [4 x i8], align 1
+  %format43 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format43, align 1
   %chars_printed44 = call i32 (ptr, ...) @printf(ptr %format43, i32 %print_value_trunc42)
-  %shifted45 = lshr i512 %rounded_size_val, 96
+  %shifted45 = lshr i512 %0, 96
   %print_value_trunc46 = trunc i512 %shifted45 to i32
-  %format47 = alloca [4 x i8], align 1
+  %format47 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format47, align 1
   %chars_printed48 = call i32 (ptr, ...) @printf(ptr %format47, i32 %print_value_trunc46)
-  %shifted49 = lshr i512 %rounded_size_val, 64
+  %shifted49 = lshr i512 %0, 64
   %print_value_trunc50 = trunc i512 %shifted49 to i32
-  %format51 = alloca [4 x i8], align 1
+  %format51 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format51, align 1
   %chars_printed52 = call i32 (ptr, ...) @printf(ptr %format51, i32 %print_value_trunc50)
-  %shifted53 = lshr i512 %rounded_size_val, 32
+  %shifted53 = lshr i512 %0, 32
   %print_value_trunc54 = trunc i512 %shifted53 to i32
-  %format55 = alloca [4 x i8], align 1
+  %format55 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format55, align 1
   %chars_printed56 = call i32 (ptr, ...) @printf(ptr %format55, i32 %print_value_trunc54)
-  %shifted57 = lshr i512 %rounded_size_val, 0
+  %shifted57 = lshr i512 %0, 0
   %print_value_trunc58 = trunc i512 %shifted57 to i32
-  %format59 = alloca [4 x i8], align 1
+  %format59 = alloca [5 x i8], align 1
   store [5 x i8] c"%08X\00", ptr %format59, align 1
   %chars_printed60 = call i32 (ptr, ...) @printf(ptr %format59, i32 %print_value_trunc58)
-  %format61 = alloca [1 x i8], align 1
+  %format61 = alloca [2 x i8], align 1
   store [2 x i8] c"\0A\00", ptr %format61, align 1
   %chars_printed62 = call i32 (ptr, ...) @printf(ptr %format61)
   ret void
 }
 
-define i252 @"felt_const<2>"() {
+define i253 @modulo(i512 %0) {
 entry:
-  ret i252 2
+  %modulus = srem i512 %0, 3618502788666131213697322783095070105623107215331596699973092056135872020481
+  %res = trunc i512 %modulus to i253
+  ret i253 %res
 }
 
-define i252 @"felt_const<4>"() {
+define i253 @"felt_const<2>"() {
 entry:
-  ret i252 4
+  ret i253 2
 }
 
-define { i252, i252 } @"struct_construct<Tuple<felt, felt>>"(i252 %0, i252 %1) {
+define i253 @"felt_const<4>"() {
 entry:
-  %res_ptr = alloca { i252, i252 }, align 8
-  %field_0_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 0
-  store i252 %0, ptr %field_0_ptr, align 4
-  %field_1_ptr = getelementptr inbounds { i252, i252 }, ptr %res_ptr, i32 0, i32 1
-  store i252 %1, ptr %field_1_ptr, align 4
-  %res = load { i252, i252 }, ptr %res_ptr, align 4
-  ret { i252, i252 } %res
+  ret i253 4
 }
 
-define { i252, i252 } @"store_temp<Tuple<felt, felt>>"({ i252, i252 } %0) {
+define { i253, i253 } @"struct_construct<Tuple<felt, felt>>"(i253 %0, i253 %1) {
 entry:
-  ret { i252, i252 } %0
+  %res_ptr = alloca { i253, i253 }, align 8
+  %field_0_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 0
+  store i253 %0, ptr %field_0_ptr, align 4
+  %field_1_ptr = getelementptr inbounds { i253, i253 }, ptr %res_ptr, i32 0, i32 1
+  store i253 %1, ptr %field_1_ptr, align 4
+  %res = load { i253, i253 }, ptr %res_ptr, align 4
+  ret { i253, i253 } %res
 }
 
-define { { i252, i252 } } @"struct_construct::struct_construct::complex_type"() {
+define { i253, i253 } @"store_temp<Tuple<felt, felt>>"({ i253, i253 } %0) {
 entry:
-  %0 = call i252 @"felt_const<2>"()
-  %1 = call i252 @"felt_const<4>"()
-  %2 = call { i252, i252 } @"struct_construct<Tuple<felt, felt>>"(i252 %0, i252 %1)
-  %3 = call { i252, i252 } @"store_temp<Tuple<felt, felt>>"({ i252, i252 } %2)
-  %ret_struct_ptr = alloca { { i252, i252 } }, align 8
-  %field_0_ptr = getelementptr inbounds { { i252, i252 } }, ptr %ret_struct_ptr, i32 0, i32 0
-  store { i252, i252 } %3, ptr %field_0_ptr, align 4
-  %return_struct_value = load { { i252, i252 } }, ptr %ret_struct_ptr, align 4
-  ret { { i252, i252 } } %return_struct_value
+  ret { i253, i253 } %0
+}
+
+define { { i253, i253 } } @"struct_construct::struct_construct::complex_type"() {
+entry:
+  %0 = call i253 @"felt_const<2>"()
+  %1 = call i253 @"felt_const<4>"()
+  %2 = call { i253, i253 } @"struct_construct<Tuple<felt, felt>>"(i253 %0, i253 %1)
+  %3 = call { i253, i253 } @"store_temp<Tuple<felt, felt>>"({ i253, i253 } %2)
+  %ret_struct_ptr = alloca { { i253, i253 } }, align 8
+  %field_0_ptr = getelementptr inbounds { { i253, i253 } }, ptr %ret_struct_ptr, i32 0, i32 0
+  store { i253, i253 } %3, ptr %field_0_ptr, align 4
+  %return_struct_value = load { { i253, i253 } }, ptr %ret_struct_ptr, align 4
+  ret { { i253, i253 } } %return_struct_value
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The llvm felt representation was too small so when a signed extend was done it would break the modulo
The print function would add 00 in the middle of a number  (ex: 2**512 -1)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Felt size increased by 1 bit
- Modulo works as expected
- print is fixed

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
