### PR TITLE
feat(core): move debug data to it's own struct

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ll linguist-generated

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ num-bigint = "0.4"
 thiserror = "1.0.38"
 test-case = "3.0.0"
 tracing = "0.1.37"
+regex = "1.7.1"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
@@ -24,4 +25,3 @@ tinytemplate = "1.2.1"
 serde = { version = "1.0.152", features = ["derive"] }
 num-bigint = "0.4.3"
 num-traits = "0.2.15"
-regex = "1.7.1"

--- a/core/src/sierra/corelib_functions/boxes/into_box.rs
+++ b/core/src/sierra/corelib_functions/boxes/into_box.rs
@@ -16,7 +16,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the type T has not been declared previously as all types should be declared at the
     /// beginning of the sierra file.
-    pub fn into_box(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn into_box(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // This function is completely irrelevant for LLVM IR but for simplicity we implement it like rename
         // for now.
         // Get the type that this into_box function has to handle
@@ -43,7 +43,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined into_box to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/boxes/into_box.rs
+++ b/core/src/sierra/corelib_functions/boxes/into_box.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Panics if the type has not been declared.
         let func_and_arg_type = self.types_by_id.get(&type_id).unwrap().as_basic_type_enum();
-        let debug_func_and_arg_type = *self.debug_types_by_id.get(&type_id).unwrap();
+        let debug_func_and_arg_type = *self.debug.types_by_id.get(&type_id).unwrap();
 
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
 
@@ -43,7 +43,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined into_box to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/boxes/unbox.rs
+++ b/core/src/sierra/corelib_functions/boxes/unbox.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Panics if the type has not been declared.
         let func_and_arg_type = self.types_by_id.get(&type_id).unwrap().as_basic_type_enum();
-        let debug_func_and_arg_type = *self.debug_types_by_id.get(&type_id).unwrap();
+        let debug_func_and_arg_type = *self.debug.types_by_id.get(&type_id).unwrap();
 
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
 
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined unbox to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/boxes/unbox.rs
+++ b/core/src/sierra/corelib_functions/boxes/unbox.rs
@@ -16,7 +16,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the type T has not been declared previously as all types should be declared at the
     /// beginning of the sierra file.
-    pub fn unbox(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn unbox(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // This function is completely irrelevant for LLVM IR but for simplicity we implement it like rename
         // for now.
         // Get the type that this unbox function has to handle
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined unbox to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/math/add.rs
+++ b/core/src/sierra/corelib_functions/math/add.rs
@@ -18,7 +18,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     pub fn felt_add(&self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
-        let debug_felt_type = *self.debug_types_by_name.get("felt").expect("Can't get felt from name");
+        let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
 
         // fn felt_add(a: felt, b: felt) -> felt
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 

--- a/core/src/sierra/corelib_functions/math/add.rs
+++ b/core/src/sierra/corelib_functions/math/add.rs
@@ -15,7 +15,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the felt type has not been declared previously or if the module felt function has
     /// not been declared previously.
-    pub fn felt_add(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn felt_add(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
         let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 

--- a/core/src/sierra/corelib_functions/math/constants.rs
+++ b/core/src/sierra/corelib_functions/math/constants.rs
@@ -19,13 +19,13 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
         let return_type = self.types_by_name.get("felt").expect("Can't get felt from name");
-        let debug_return_type = *self.debug_types_by_name.get("felt").expect("Can't get felt from name");
+        let debug_return_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
 
         // fn felt_const() -> felt
         let func = self.module.add_function(func_name, return_type.fn_type(&[], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.create_function_debug(func_name, &func, Some(debug_return_type), &[]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_return_type), &[]);
 
         // Convert the bigint value of the constant into an LLVM IR const int value. Panics if the constant
         // value is not a decimal value.

--- a/core/src/sierra/corelib_functions/math/constants.rs
+++ b/core/src/sierra/corelib_functions/math/constants.rs
@@ -15,7 +15,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     /// # Error
     ///
     /// Panics if the felt type has not been declared previously.
-    pub fn felt_const(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn felt_const(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
         let return_type = self.types_by_name.get("felt").expect("Can't get felt from name");
@@ -25,7 +25,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func = self.module.add_function(func_name, return_type.fn_type(&[], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_return_type), &[]);
+        self.debug.create_function(func_name, &func, Some(debug_return_type), &[], None);
 
         // Convert the bigint value of the constant into an LLVM IR const int value. Panics if the constant
         // value is not a decimal value.

--- a/core/src/sierra/corelib_functions/math/modulo.rs
+++ b/core/src/sierra/corelib_functions/math/modulo.rs
@@ -22,7 +22,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func = self.module.add_function("modulo", felt_type.fn_type(&[big_felt_type.into()], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.debug.create_function_debug("modulo", &func, Some(debug_felt_type), &[debug_double_felt_type]);
+        self.debug.create_function("modulo", &func, Some(debug_felt_type), &[debug_double_felt_type], None);
 
         let prime = big_felt_type.const_int_from_string(DEFAULT_PRIME, inkwell::types::StringRadix::Decimal).unwrap();
         // smod

--- a/core/src/sierra/corelib_functions/math/modulo.rs
+++ b/core/src/sierra/corelib_functions/math/modulo.rs
@@ -12,17 +12,17 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     pub fn modulo(&mut self) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
-        let debug_felt_type = *self.debug_types_by_name.get("felt").expect("Can't get felt from name");
+        let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
         // Max size of felt operation (Prime - 1 ) * ( Prime - 1) = 503 bits number
         let big_felt_type = self.context.custom_width_int_type(512);
         let debug_double_felt_type =
-            *self.debug_types_by_name.get("double_felt").expect("Can't get double felt from name");
+            *self.debug.types_by_name.get("double_felt").expect("Can't get double felt from name");
 
         // fn felt_modulo(a: double_felt) -> felt
         let func = self.module.add_function("modulo", felt_type.fn_type(&[big_felt_type.into()], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.create_function_debug("modulo", &func, Some(debug_felt_type), &[debug_double_felt_type]);
+        self.debug.create_function_debug("modulo", &func, Some(debug_felt_type), &[debug_double_felt_type]);
 
         let prime = big_felt_type.const_int_from_string(DEFAULT_PRIME, inkwell::types::StringRadix::Decimal).unwrap();
         // smod

--- a/core/src/sierra/corelib_functions/math/mul.rs
+++ b/core/src/sierra/corelib_functions/math/mul.rs
@@ -18,7 +18,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     pub fn felt_mul(&self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
-        let debug_felt_type = *self.debug_types_by_name.get("felt").expect("Can't get felt from name");
+        let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
         // fn felt_mul(a: felt, b: felt) -> felt
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
         let func = self.module.add_function(
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         );
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
 
         // The maximum value of a multiplication is (prime - 1)² which is 503 bits.
         let double_felt = self.context.custom_width_int_type(512);

--- a/core/src/sierra/corelib_functions/math/mul.rs
+++ b/core/src/sierra/corelib_functions/math/mul.rs
@@ -15,7 +15,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the felt type has not been declared previously or if the module felt function has
     /// not been declared previously.
-    pub fn felt_mul(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn felt_mul(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
         let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         );
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type], None);
 
         // The maximum value of a multiplication is (prime - 1)² which is 503 bits.
         let double_felt = self.context.custom_width_int_type(512);

--- a/core/src/sierra/corelib_functions/math/sub.rs
+++ b/core/src/sierra/corelib_functions/math/sub.rs
@@ -15,7 +15,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the felt type has not been declared previously or if the module felt function has
     /// not been declared previously.
-    pub fn felt_sub(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn felt_sub(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
         let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         );
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type], None);
 
         // Return a - b
         // Panics if the function doesn't have enough arguments but it should happen since we just defined

--- a/core/src/sierra/corelib_functions/math/sub.rs
+++ b/core/src/sierra/corelib_functions/math/sub.rs
@@ -18,7 +18,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     pub fn felt_sub(&self, libfunc_declaration: &LibfuncDeclaration) {
         // We could hardcode the LLVM IR type for felt but this adds a check.
         let felt_type = self.types_by_name.get("felt").expect("Can't get felt from name");
-        let debug_felt_type = *self.debug_types_by_name.get("felt").expect("Can't get felt from name");
+        let debug_felt_type = *self.debug.types_by_name.get("felt").expect("Can't get felt from name");
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
         // fn felt_sub(a: felt, b: felt) -> felt
         let func = self.module.add_function(
@@ -28,7 +28,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         );
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_felt_type), &[debug_felt_type, debug_felt_type]);
 
         // Return a - b
         // Panics if the function doesn't have enough arguments but it should happen since we just defined

--- a/core/src/sierra/corelib_functions/memory/dup.rs
+++ b/core/src/sierra/corelib_functions/memory/dup.rs
@@ -37,9 +37,9 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Return a 2 element struct that have the same value. Ex: dup<felt>(1) -> { i252 1, i252 1 }
         let return_type = self.context.struct_type(&[arg_type, arg_type], false);
 
-        let debug_return_type = self.debug.create_debug_type_struct(
-            self.debug.get_debug_function_return_struct_type_id(libfunc_declaration.id.id),
-            &self.debug.get_debug_function_return_struct_type_name(func_name),
+        let debug_return_type = self.debug.create_struct(
+            self.debug.get_fn_struct_type_id(libfunc_declaration.id.id),
+            &self.debug.get_fn_struct_type_name(func_name),
             &return_type,
             &[debug_arg_type],
         );
@@ -51,7 +51,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_return_type), &[debug_arg_type]);
+        self.debug.create_function(func_name, &func, Some(debug_return_type), &[debug_arg_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined dup to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/memory/dup.rs
+++ b/core/src/sierra/corelib_functions/memory/dup.rs
@@ -32,14 +32,14 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
 
         let arg_type = *self.types_by_id.get(&arg_type_id).unwrap();
-        let debug_arg_type = *self.debug_types_by_id.get(&arg_type_id).unwrap();
+        let debug_arg_type = *self.debug.types_by_id.get(&arg_type_id).unwrap();
 
         // Return a 2 element struct that have the same value. Ex: dup<felt>(1) -> { i252 1, i252 1 }
         let return_type = self.context.struct_type(&[arg_type, arg_type], false);
 
-        let debug_return_type = self.create_debug_type_struct(
-            Self::get_debug_function_return_struct_type_id(libfunc_declaration.id.id),
-            &Self::get_debug_function_return_struct_type_name(func_name),
+        let debug_return_type = self.debug.create_debug_type_struct(
+            self.debug.get_debug_function_return_struct_type_id(libfunc_declaration.id.id),
+            &self.debug.get_debug_function_return_struct_type_name(func_name),
             &return_type,
             &[debug_arg_type],
         );
@@ -51,7 +51,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             None,
         );
 
-        self.create_function_debug(func_name, &func, Some(debug_return_type), &[debug_arg_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_return_type), &[debug_arg_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined dup to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/memory/rename.rs
+++ b/core/src/sierra/corelib_functions/memory/rename.rs
@@ -16,7 +16,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the type T has not been declared previously as all types should be declared at the
     /// beginning of the sierra file.
-    pub fn rename(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn rename(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // This function just dumbly returns its input value. When it's called it just stores the value in
         // the next variable. Not sure how relevant it is in LLVM but might be useful later for branching.
         // Get the type that this rename function has to handle
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined rename to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/memory/rename.rs
+++ b/core/src/sierra/corelib_functions/memory/rename.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Panics if the type has not been declared.
         let func_and_arg_type = self.types_by_id.get(&type_id).unwrap().as_basic_type_enum();
-        let debug_func_and_arg_type = *self.debug_types_by_id.get(&type_id).unwrap();
+        let debug_func_and_arg_type = *self.debug.types_by_id.get(&type_id).unwrap();
 
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
 
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined rename to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/memory/store_temp.rs
+++ b/core/src/sierra/corelib_functions/memory/store_temp.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Panics if the type has not been declared.
         let func_and_arg_type = self.types_by_id.get(&type_id).unwrap().as_basic_type_enum();
-        let debug_func_and_arg_type = *self.debug_types_by_id.get(&type_id).unwrap();
+        let debug_func_and_arg_type = *self.debug.types_by_id.get(&type_id).unwrap();
 
         let func_name = libfunc_declaration.id.debug_name.as_ref().expect(DEBUG_NAME_EXPECTED).as_str();
 
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined store_temp to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/corelib_functions/memory/store_temp.rs
+++ b/core/src/sierra/corelib_functions/memory/store_temp.rs
@@ -16,7 +16,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     ///
     /// Panics if the type T has not been declared previously as all types should be declared at the
     /// beginning of the sierra file.
-    pub fn store_temp(&self, libfunc_declaration: &LibfuncDeclaration) {
+    pub fn store_temp(&mut self, libfunc_declaration: &LibfuncDeclaration) {
         // This function is completely irrelevant for LLVM IR but for simplicity we implement it like rename
         // for now. In cairo this function is used to store something in a tempvar.
         // Get the type that this store_temp function has to handle
@@ -40,7 +40,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func =
             self.module.add_function(func_name, func_and_arg_type.fn_type(&[func_and_arg_type.into()], false), None);
 
-        self.debug.create_function_debug(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type]);
+        self.debug.create_function(func_name, &func, Some(debug_func_and_arg_type), &[debug_func_and_arg_type], None);
 
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
         // We just defined store_temp to have an input parameter so it shouldn't panic.

--- a/core/src/sierra/debug.rs
+++ b/core/src/sierra/debug.rs
@@ -1,8 +1,11 @@
+use std::borrow::Cow;
+
 use inkwell::debug_info::{AsDIScope, DIFlags, DIFlagsConstants, DIScope, DISubprogram, DIType};
 use inkwell::types::StructType;
 use inkwell::values::FunctionValue;
+use regex::Regex;
 
-use super::llvm_compiler::DebugCompiler;
+use super::llvm_compiler::{DebugCompiler, FunctionDebugInfo};
 
 impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     /// Create and set the current debug location.
@@ -10,7 +13,7 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     pub fn debug_location(&self, scope: Option<DIScope<'ctx>>) {
         let location = self.debug_builder.create_debug_location(
             self.context,
-            self.current_line,
+            self.get_line(),
             0,
             scope.unwrap_or_else(|| self.compile_unit.as_debug_info_scope()),
             None,
@@ -22,13 +25,15 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     ///
     /// Sets the current debug location too, so you don't have to call debug_location with the
     /// returned scope.
-    pub fn create_function_debug(
-        &self,
+    pub fn create_function(
+        &mut self,
         func_name: &str,
         func: &FunctionValue<'ctx>,
         return_type: Option<DIType<'ctx>>,
         parameter_types: &[DIType<'ctx>],
+        scope_line: Option<usize>,
     ) -> DIScope<'ctx> {
+        let debug_func_name = self.clear_function_name(func_name);
         let subroutine_type = self.debug_builder.create_subroutine_type(
             self.compile_unit.get_file(),
             return_type,
@@ -37,30 +42,48 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
         );
         let func_scope: DISubprogram<'_> = self.debug_builder.create_function(
             self.compile_unit.as_debug_info_scope(),
-            func_name,
-            None,
+            &debug_func_name,
+            Some(func_name),
             self.compile_unit.get_file(),
-            self.current_line, // line number
+            self.get_line(), // line number
             subroutine_type,
             true,
             true,
-            0, // scope line
+            scope_line.map(|x| x as u32).unwrap_or_else(|| self.get_line()), // scope line
             DIFlags::PUBLIC,
             false,
         );
         func.set_subprogram(func_scope);
         let scope = func_scope.as_debug_info_scope();
+
+        let mut params = Vec::with_capacity(parameter_types.len());
+
+        for (i, param) in parameter_types.iter().enumerate() {
+            let local_var = self.debug_builder.create_parameter_variable(
+                scope,
+                &i.to_string(),
+                i as u32 + 1,
+                self.compile_unit.get_file(),
+                self.get_line(),
+                *param,
+                true,
+                DIFlags::PUBLIC,
+            );
+            params.push(local_var);
+        }
+
+        let info = FunctionDebugInfo { function: func_scope, params };
+
+        self.functions.insert(func_name.to_string(), info);
+
         self.debug_location(Some(scope));
         scope
     }
 
     /// Creates a type debug info by name.
-    pub fn create_debug_type(&mut self, id: u64, name: &str, size_in_bits: u64) -> DIType<'ctx> {
-        let debug_type = self
-            .debug_builder
-            .create_basic_type(name, size_in_bits, 0x00, inkwell::debug_info::DIFlags::PUBLIC)
-            .unwrap()
-            .as_type();
+    pub fn create_type(&mut self, id: u64, name: &str, size_in_bits: u64) -> DIType<'ctx> {
+        let debug_type =
+            self.debug_builder.create_basic_type(name, size_in_bits, 0x00, DIFlags::PUBLIC).unwrap().as_type();
 
         self.types_by_id.insert(id, debug_type);
         self.types_by_name.insert(name.to_string(), debug_type);
@@ -68,7 +91,7 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     }
 
     /// Creates a struct debug type.
-    pub fn create_debug_type_struct(
+    pub fn create_struct(
         &mut self,
         id: u64,
         name: &str,
@@ -88,7 +111,7 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
             self.compile_unit.as_debug_info_scope(),
             name,
             self.compile_unit.get_file(),
-            self.current_line,
+            self.get_line(),
             bits,
             align_bits,
             inkwell::debug_info::DIFlags::PUBLIC,
@@ -108,7 +131,7 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     ///
     /// Arbitrarily the decided function generated struct return types have id = the function id +
     /// 100_000.
-    pub const fn get_debug_function_return_struct_type_id(&self, func_id: u64) -> u64 {
+    pub const fn get_fn_struct_type_id(&self, func_id: u64) -> u64 {
         func_id + 100_000
     }
 
@@ -116,7 +139,16 @@ impl<'a, 'ctx> DebugCompiler<'a, 'ctx> {
     ///
     /// Arbitrarily decided the generated struct return types have name = "return_type_{}" where {}
     /// is the function name.
-    pub fn get_debug_function_return_struct_type_name(&self, func_debug_name: &str) -> String {
+    pub fn get_fn_struct_type_name(&self, func_debug_name: &str) -> String {
         format!("return_type_{}", func_debug_name)
+    }
+
+    /// User defined functions in sierra have a namespace before, it's not really useful for
+    /// debugging.
+    ///
+    /// a::a::fn_name -> fn_name
+    pub fn clear_function_name<'s>(&self, name: &'s str) -> Cow<'s, str> {
+        let regex = Regex::new(r#".*::"#).unwrap();
+        regex.replace(name, "")
     }
 }

--- a/core/src/sierra/process/corelib.rs
+++ b/core/src/sierra/process/corelib.rs
@@ -43,7 +43,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
         // Iterate over the libfunc declarations in the Sierra program.
         for libfunc_declaration in self.program.libfunc_declarations.iter() {
-            self.current_line_estimate += 1;
+            self.debug.next_line();
 
             // Get the debug name of the function.
             let libfunc_name = libfunc_declaration.long_id.generic_id.0.as_str();
@@ -89,6 +89,9 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 _ => debug!(libfunc_name, "not implemented"),
             }
         }
+
+        self.debug.next_line();
+
         // Move to the next state.
         self.move_to(CompilationState::CoreLibFunctionsProcessed)
     }

--- a/core/src/sierra/process/debug.rs
+++ b/core/src/sierra/process/debug.rs
@@ -21,7 +21,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // self.create_debug_type("double_felt", DOUBLE_FELT_INT_WIDTH.into());
 
         // double_felt doesn't have a numeric id from sierra.
-        self.create_debug_type(200000, "double_felt", DOUBLE_FELT_INT_WIDTH.into());
+        self.debug.create_debug_type(200000, "double_felt", DOUBLE_FELT_INT_WIDTH.into());
 
         self.move_to(CompilationState::DebugSetup)
     }

--- a/core/src/sierra/process/debug.rs
+++ b/core/src/sierra/process/debug.rs
@@ -21,7 +21,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // self.create_debug_type("double_felt", DOUBLE_FELT_INT_WIDTH.into());
 
         // double_felt doesn't have a numeric id from sierra.
-        self.debug.create_debug_type(200000, "double_felt", DOUBLE_FELT_INT_WIDTH.into());
+        self.debug.create_type(200000, "double_felt", DOUBLE_FELT_INT_WIDTH.into());
 
         self.move_to(CompilationState::DebugSetup)
     }

--- a/core/src/sierra/process/funcs.rs
+++ b/core/src/sierra/process/funcs.rs
@@ -69,9 +69,9 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                     // Arbitrarely decided generated struct return types have id = the function id + 100_000.
                     // Arbitrarely decided generated struct return types have name = "return_type_{}" where {} is the
                     // function name.
-                    let debug_type = self.debug.create_debug_type_struct(
-                        self.debug.get_debug_function_return_struct_type_id(func_declaration.id.id),
-                        &self.debug.get_debug_function_return_struct_type_name(func_name),
+                    let debug_type = self.debug.create_struct(
+                        self.debug.get_fn_struct_type_id(func_declaration.id.id),
+                        &self.debug.get_fn_struct_type_name(func_name),
                         &generated_return_struct_type,
                         &ret_debug_types,
                     );
@@ -135,7 +135,13 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
 
             self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-            let scope = self.debug.create_function_debug(func_name, &func, return_info.map(|x| x.1), &args_debug_types);
+            let scope = self.debug.create_function(
+                func_name,
+                &func,
+                return_info.map(|x| x.1),
+                &args_debug_types,
+                Some(func_declaration.entry_point.0),
+            );
 
             // Loop through the arguments of the function. The variable id counter always starts from zero for a
             // function.

--- a/core/src/sierra/process/statements.rs
+++ b/core/src/sierra/process/statements.rs
@@ -22,12 +22,13 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
             // Set the statement number to the absolute statement number.
             statement_id += from;
             self.debug.set_statement_line(statement_id);
+            self.debug.debug_location(Some(scope));
             match statement {
                 // If the statement is a sierra function call.
                 GenStatement::Invocation(invocation) => {
                     // Get core lib function called by this instruction.
                     let fn_name = invocation.libfunc_id.debug_name.clone().expect(DEBUG_NAME_EXPECTED).to_string();
-                    debug!(fn_name, self.debug.current_statement_line, "processing statement: invocation");
+                    debug!(fn_name, line = self.debug.get_line(), "processing statement: invocation");
                     // Function has only one branch and doesn't return anything.
                     if invocation.branches.len() == 1 && invocation.branches[0].results.is_empty() {
                         match fn_name.as_str() {
@@ -130,7 +131,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                         .unwrap()
                         .to_string();
 
-                    debug!(func_name, self.debug.current_statement_line, "processing statement: return");
+                    debug!(func_name, line = self.debug.get_line(), "processing statement: return");
                     // If there is actually something to return.
                     if !ret.is_empty() {
                         let mut types = vec![];

--- a/core/src/sierra/process/types.rs
+++ b/core/src/sierra/process/types.rs
@@ -18,7 +18,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Check that the current state is valid.
         self.check_state(&CompilationState::DebugSetup)?;
         for type_declaration in self.program.type_declarations.iter() {
-            self.current_line_estimate += 1;
+            self.debug.next_line();
             // All those types are known in advance. A struct is a combination of multiple "primitive" types
             let type_name = type_declaration.long_id.generic_id.0.as_str();
             match type_name {
@@ -33,6 +33,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 _ => debug!(type_name, "unimplemented type"),
             }
         }
+        self.debug.next_line();
         // Move to the next state.
         self.move_to(CompilationState::TypesProcessed)
     }

--- a/core/src/sierra/statements_processing/jump/jumps.rs
+++ b/core/src/sierra/statements_processing/jump/jumps.rs
@@ -1,3 +1,5 @@
+use inkwell::debug_info::DIScope;
+
 use crate::sierra::llvm_compiler::Compiler;
 
 impl<'a, 'ctx> Compiler<'a, 'ctx> {
@@ -11,7 +13,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     /// # Error
     ///
     /// Returns an error if the processing of the branches statements fails.
-    pub fn jump(&mut self, dest_nb: usize) {
+    pub fn jump(&mut self, dest_nb: usize, scope: DIScope<'ctx>) {
         // Get the function that's currently processed.
         // It shouldn't panic as if we're there at least a function has to have been declared
         let func = self.module.get_last_function().unwrap();
@@ -27,6 +29,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         self.basic_blocks.insert(dest_nb, destination);
         self.builder.position_at_end(destination);
         // Keep processing the statements.
-        self.process_statements_from(dest_nb).unwrap();
+        self.process_statements_from(dest_nb, scope).unwrap();
     }
 }

--- a/core/src/sierra/statements_processing/printf/mod.rs
+++ b/core/src/sierra/statements_processing/printf/mod.rs
@@ -20,7 +20,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func = self.module.add_function(func_name, void_type.fn_type(&[ty], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.create_function_debug(func_name, &func, None, &[*self.debug_types_by_name.get(type_name).unwrap()]);
+        self.debug.create_function_debug(func_name, &func, None, &[*self.debug.types_by_name.get(type_name).unwrap()]);
 
         // For now we only allow printing int types.
         let value = func.get_first_param().expect("Function should have exactly 1 param").into_int_value();

--- a/core/src/sierra/statements_processing/printf/mod.rs
+++ b/core/src/sierra/statements_processing/printf/mod.rs
@@ -8,7 +8,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
     /// Defines a function that wraps printf to print a value of type `ty`.
     /// Useful for debugging, specially for integers with a size > 64bit.
     /// Requires printf to be declared beforehand.
-    pub fn printf_for_type(&self, ty: BasicMetadataTypeEnum<'ctx>, func_name: &str, type_name: &str) {
+    pub fn printf_for_type(&mut self, ty: BasicMetadataTypeEnum<'ctx>, func_name: &str, type_name: &str) {
         if self.module.get_function(func_name).is_some() {
             warn!("Tried to redefine {} printf function.", func_name);
             return;
@@ -20,7 +20,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         let func = self.module.add_function(func_name, void_type.fn_type(&[ty], false), None);
         self.builder.position_at_end(self.context.append_basic_block(func, "entry"));
 
-        self.debug.create_function_debug(func_name, &func, None, &[*self.debug.types_by_name.get(type_name).unwrap()]);
+        self.debug.create_function(func_name, &func, None, &[*self.debug.types_by_name.get(type_name).unwrap()], None);
 
         // For now we only allow printing int types.
         let value = func.get_first_param().expect("Function should have exactly 1 param").into_int_value();

--- a/core/src/sierra/types/felt.rs
+++ b/core/src/sierra/types/felt.rs
@@ -21,6 +21,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Save the felt type in the types map.
         self.types_by_id.insert(type_declaration.id.id, felt_type);
         self.types_by_name.insert(debug_name.to_string(), felt_type);
-        self.create_debug_type(type_declaration.id.id, debug_name, FELT_INT_WIDTH.into());
+        self.debug.create_debug_type(type_declaration.id.id, debug_name, FELT_INT_WIDTH.into());
     }
 }

--- a/core/src/sierra/types/felt.rs
+++ b/core/src/sierra/types/felt.rs
@@ -21,6 +21,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         // Save the felt type in the types map.
         self.types_by_id.insert(type_declaration.id.id, felt_type);
         self.types_by_name.insert(debug_name.to_string(), felt_type);
-        self.debug.create_debug_type(type_declaration.id.id, debug_name, FELT_INT_WIDTH.into());
+        self.debug.create_type(type_declaration.id.id, debug_name, FELT_INT_WIDTH.into());
     }
 }

--- a/core/src/sierra/types/non_zero.rs
+++ b/core/src/sierra/types/non_zero.rs
@@ -26,13 +26,13 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 // everything is provable but in LLVM IR we're not proving anything so we can consider `NonZero<T>`
                 // to be just `T`).
                 let inner_type = *self.types_by_id.get(id).unwrap();
-                let debug_inner_type = *self.debug_types_by_id.get(id).unwrap();
+                let debug_inner_type = *self.debug.types_by_id.get(id).unwrap();
 
                 self.types_by_id.insert(type_declaration.id.id, inner_type);
                 self.types_by_name.insert(type_declaration.id.debug_name.as_ref().unwrap().to_string(), inner_type);
 
                 let debug_name = type_declaration.id.debug_name.as_ref().unwrap().to_string();
-                self.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
+                self.debug.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
             }
             GenericArg::UserType(_) => todo!(),
             _val => {

--- a/core/src/sierra/types/non_zero.rs
+++ b/core/src/sierra/types/non_zero.rs
@@ -32,7 +32,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 self.types_by_name.insert(type_declaration.id.debug_name.as_ref().unwrap().to_string(), inner_type);
 
                 let debug_name = type_declaration.id.debug_name.as_ref().unwrap().to_string();
-                self.debug.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
+                self.debug.create_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
             }
             GenericArg::UserType(_) => todo!(),
             _val => {

--- a/core/src/sierra/types/sierra_box.rs
+++ b/core/src/sierra/types/sierra_box.rs
@@ -15,7 +15,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 // A type can't use an undefined type so it should be declared before so it shouldn't panic.
                 // The box type is ignored in LLVM IR we just define `Box<T>` as `T`.
                 let inner_type = *self.types_by_id.get(id).unwrap();
-                let debug_inner_type = *self.debug_types_by_id.get(id).unwrap();
+                let debug_inner_type = *self.debug.types_by_id.get(id).unwrap();
 
                 let debug_name = type_declaration.id.debug_name.as_ref().unwrap().as_str();
 
@@ -23,7 +23,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 self.types_by_name.insert(debug_name.to_string(), inner_type);
 
                 let debug_name = type_declaration.id.debug_name.as_ref().unwrap().to_string();
-                self.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
+                self.debug.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
             }
             GenericArg::UserType(_) => todo!(),
             _val => {

--- a/core/src/sierra/types/sierra_box.rs
+++ b/core/src/sierra/types/sierra_box.rs
@@ -23,7 +23,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                 self.types_by_name.insert(debug_name.to_string(), inner_type);
 
                 let debug_name = type_declaration.id.debug_name.as_ref().unwrap().to_string();
-                self.debug.create_debug_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
+                self.debug.create_type(type_declaration.id.id, &debug_name, debug_inner_type.get_size_in_bits());
             }
             GenericArg::UserType(_) => todo!(),
             _val => {

--- a/core/src/sierra/types/sierra_struct.rs
+++ b/core/src/sierra/types/sierra_struct.rs
@@ -39,6 +39,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         self.types_by_id.insert(type_declaration.id.id, struct_type.as_basic_type_enum());
         self.types_by_name.insert(debug_name.to_string(), struct_type.as_basic_type_enum());
 
-        self.debug.create_debug_type_struct(type_declaration.id.id, debug_name, &struct_type, &debug_args);
+        self.debug.create_struct(type_declaration.id.id, debug_name, &struct_type, &debug_args);
     }
 }

--- a/core/src/sierra/types/sierra_struct.rs
+++ b/core/src/sierra/types/sierra_struct.rs
@@ -23,7 +23,7 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
                             .expect("Type should have been defined before struct")
                             .as_basic_type_enum(),
                     );
-                    debug_args.push(*self.debug_types_by_id.get(id).unwrap());
+                    debug_args.push(*self.debug.types_by_id.get(id).unwrap());
                 }
                 // Ignore the user type as it is not a struct field.
                 GenericArg::UserType(_) => continue,
@@ -39,6 +39,6 @@ impl<'a, 'ctx> Compiler<'a, 'ctx> {
         self.types_by_id.insert(type_declaration.id.id, struct_type.as_basic_type_enum());
         self.types_by_name.insert(debug_name.to_string(), struct_type.as_basic_type_enum());
 
-        self.create_debug_type_struct(type_declaration.id.id, debug_name, &struct_type, &debug_args);
+        self.debug.create_debug_type_struct(type_declaration.id.id, debug_name, &struct_type, &debug_args);
     }
 }


### PR DESCRIPTION
This moves all the data to a DebugCompiler struct, so its a bit more self contained.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):